### PR TITLE
Fix: Antigravity global location path for skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,13 +142,13 @@ npm run release
 
 The CLI installs skills to these locations:
 
-| Agent          | Local Path          | Global Path           |
-| -------------- | ------------------- | --------------------- |
-| Antigravity    | `.agent/skills/`    | `~/.agent/skills/`    |
-| Claude Code    | `.claude/skills/`   | `~/.claude/skills/`   |
-| Cursor         | `.cursor/skills/`   | `~/.cursor/skills/`   |
-| GitHub Copilot | `.github/skills/`   | `~/.copilot/skills/`  |
-| OpenCode       | `.opencode/skills/` | `~/.opencode/skills/` |
+| Agent          | Local Path          | Global Path                            |
+| -------------- | ------------------- | -------------------------------------- |
+| Antigravity    | `.agent/skills/`    | `~/.gemini/antigravity/global_skills/` |
+| Claude Code    | `.claude/skills/`   | `~/.claude/skills/`                    |
+| Cursor         | `.cursor/skills/`   | `~/.cursor/skills/`                    |
+| GitHub Copilot | `.github/skills/`   | `~/.copilot/skills/`                   |
+| OpenCode       | `.opencode/skills/` | `~/.opencode/skills/`                  |
 
 ## Testing Skills
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Each step shows a **← Back** option to return to the previous step and revise 
 # Interactive mode (default)
 npx @tech-leads-club/agent-skills
 
-# Install globally (to ~/.agent/skills, ~/.claude/skills, etc.)
+# Install globally (to ~/.gemini/antigravity/global_skills, ~/.claude/skills, etc.)
 npx @tech-leads-club/agent-skills install -g
 
 # List available skills
@@ -106,18 +106,18 @@ Skills are organized by category for easier navigation.
 
 ### 🔧 Development
 
-| Skill | Description |
-|-------|-------------|
+| Skill               | Description                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | **spec-driven-dev** | Specification-driven development workflow with 4 phases: specify → design → tasks → implement+validate |
 
 ### 🛠 Skill & Agent Creation
 
-| Skill | Description |
-|-------|-------------|
-| **skill-creator** | Meta-skill for creating new skills following best practices |
-| **subagent-creator** | Create specialized subagents for complex tasks |
-| **cursor-skill-creator** | Cursor-specific skill creation |
-| **cursor-subagent-creator** | Cursor-specific subagent creation |
+| Skill                       | Description                                                 |
+| --------------------------- | ----------------------------------------------------------- |
+| **skill-creator**           | Meta-skill for creating new skills following best practices |
+| **subagent-creator**        | Create specialized subagents for complex tasks              |
+| **cursor-skill-creator**    | Cursor-specific skill creation                              |
+| **cursor-subagent-creator** | Cursor-specific subagent creation                           |
 
 ---
 
@@ -144,16 +144,16 @@ npm run build
 
 ### Development Commands
 
-| Command | Description |
-|---------|-------------|
-| `npm run start:dev` | Run CLI locally (interactive mode) |
-| `npm run g <name>` | Generate a new skill |
-| `npm run build` | Build all packages |
-| `npm run test` | Run all tests |
-| `npm run lint` | Lint codebase |
-| `npm run lint:fix` | Fix lint issues |
-| `npm run format` | Format code with Prettier |
-| `npm run release:dry` | Preview release (dry-run) |
+| Command               | Description                        |
+| --------------------- | ---------------------------------- |
+| `npm run start:dev`   | Run CLI locally (interactive mode) |
+| `npm run g <name>`    | Generate a new skill               |
+| `npm run build`       | Build all packages                 |
+| `npm run test`        | Run all tests                      |
+| `npm run lint`        | Lint codebase                      |
+| `npm run lint:fix`    | Fix lint issues                    |
+| `npm run format`      | Format code with Prettier          |
+| `npm run release:dry` | Preview release (dry-run)          |
 
 ### Creating a New Skill
 
@@ -280,13 +280,13 @@ agent-skills/
 
 This project uses **NX Release** with **Conventional Commits** for automated versioning:
 
-| Commit Prefix | Version Bump | Example |
-|---------------|--------------|---------|
-| `feat:` | Minor (0.X.0) | `feat: add new skill` |
-| `fix:` | Patch (0.0.X) | `fix: correct symlink path` |
-| `feat!:` | Major (X.0.0) | `feat!: breaking API change` |
-| `docs:` | No bump | `docs: update README` |
-| `chore:` | No bump | `chore: update deps` |
+| Commit Prefix | Version Bump  | Example                      |
+| ------------- | ------------- | ---------------------------- |
+| `feat:`       | Minor (0.X.0) | `feat: add new skill`        |
+| `fix:`        | Patch (0.0.X) | `fix: correct symlink path`  |
+| `feat!:`      | Major (X.0.0) | `feat!: breaking API change` |
+| `docs:`       | No bump       | `docs: update README`        |
+| `chore:`      | No bump       | `chore: update deps`         |
 
 Releases are automated via GitHub Actions when merging to `main`.
 

--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -81,7 +81,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     displayName: 'Antigravity',
     description: "Google's agentic coding (VS Code)",
     skillsDir: '.agent/skills',
-    globalSkillsDir: join(home, '.agent/skills'),
+    globalSkillsDir: join(home, '.gemini/antigravity/global_skills'),
     detectInstalled: () => existsSync(join(home, '.gemini/antigravity')) || existsSync(join(projectRoot, '.agent')),
   },
   roo: {


### PR DESCRIPTION
This pull request updates documentation and configuration to change the global skills directory for the Antigravity agent from `~/.agent/skills` to `~/.gemini/antigravity/global_skills`. It also standardizes table formatting in documentation for improved readability.

**Antigravity agent global skills directory update:**

* Changed the global skills directory for the Antigravity agent in `packages/cli/src/agents.ts` to `~/.gemini/antigravity/global_skills` instead of `~/.agent/skills`.
* Updated documentation in `README.md` and `AGENTS.md` to reflect the new global path for Antigravity agent skills [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L146-R147).

**Documentation formatting improvements:**

* Standardized markdown table formatting across multiple sections in `README.md` for consistency and better readability [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R116) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R148) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L284-R284).