### PR TITLE
feat: add letsfg flight search and booking skill

### DIFF
--- a/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
+++ b/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: letsfg
-description: >-
-  Agent-native flight search and booking via 180+ airline connectors. Returns raw
-  airline prices with zero markup — $20–50 cheaper than OTAs. Use when user asks to
-  "find flights", "search flights", "book a flight", "compare airline prices",
-  "find cheap flights", "fly from X to Y", or any flight-related travel query.
-  Do NOT use for hotel-only searches (use hotel skills), car rentals, or non-flight
-  travel bookings.
+description: Agent-native flight search and booking via 180+ airline connectors. Returns raw airline prices with zero markup — $20–50 cheaper than OTAs. Use when user asks to "find flights", "search flights", "book a flight", "compare airline prices", "find cheap flights", "fly from X to Y", or any flight-related travel query. Do NOT use for hotel-only searches (use hotel skills), car rentals, or non-flight travel bookings.
 license: MIT
 metadata:
   author: LetsFG - github.com/LetsFG
@@ -162,6 +156,16 @@ letsfg unlock off_xxx
 
 ### 4. Book (Ticket Price Only)
 
+**Before your first booking**, attach a payment method:
+
+```bash
+letsfg setup-payment
+```
+
+Or via Python: `bt.setup_payment(token="tok_visa")`
+
+Then book:
+
 ```python
 booking = bt.book(
     offer_id=unlocked.offer_id,
@@ -229,7 +233,8 @@ if candidates:
 | `RATE_LIMITED` (429) | Transient | Wait and retry |
 | `INVALID_IATA` (422) | Validation | Use `resolve_location()` to fix |
 | `OFFER_EXPIRED` (410) | Business | Search again for fresh offers |
-| `PAYMENT_REQUIRED` (402) | Business | Run `letsfg star --github <username>` |
+| `OFFER_NOT_UNLOCKED` (403) | Business | Run `letsfg star --github <username>` |
+| `PAYMENT_REQUIRED` (402) | Business | Run `letsfg setup-payment` to attach a card |
 | `FARE_CHANGED` (409) | Business | Re-unlock to get current price |
 
 ```python
@@ -241,8 +246,10 @@ except OfferExpiredError:
     # Airline sold the seats — search again
     flights = bt.search(origin, dest, date)
 except PaymentRequiredError:
-    # GitHub star not verified
-    print("Star the repo: letsfg star --github <username>")
+    # No payment method attached — run setup-payment
+    print("Attach a card: letsfg setup-payment")
+# HTTP 403 on unlock means GitHub star not verified:
+# Run: letsfg star --github <username>
 ```
 
 ## Search Flags
@@ -265,7 +272,7 @@ except PaymentRequiredError:
 |-----------|------|---------------|------------|
 | `search` | Free | Yes | Yes |
 | `resolve_location` | Free | Yes | Yes |
-| `unlock` | Free | No — may charge fee | No |
+| `unlock` | Free (requires GitHub star) | Yes | No |
 | `book` | Ticket price | Only with `idempotency_key` | With key: yes |
 
 ## Reference Files

--- a/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
+++ b/packages/skills-catalog/skills/(tooling)/letsfg/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: letsfg
+description: >-
+  Agent-native flight search and booking via 180+ airline connectors. Returns raw
+  airline prices with zero markup — $20–50 cheaper than OTAs. Use when user asks to
+  "find flights", "search flights", "book a flight", "compare airline prices",
+  "find cheap flights", "fly from X to Y", or any flight-related travel query.
+  Do NOT use for hotel-only searches (use hotel skills), car rentals, or non-flight
+  travel bookings.
+license: MIT
+metadata:
+  author: LetsFG - github.com/LetsFG
+  version: '1.0.0'
+---
+
+# LetsFG
+
+Agent-native flight search and booking. 180+ airline connectors, zero markup,
+$20–50 cheaper than travel websites.
+
+**Three-step flow:** Search (free) → Unlock (free) → Book (ticket price only)
+
+## Why Use This
+
+- **180+ airlines in parallel** — Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, Qantas, LATAM, Spirit, Frontier, IndiGo, VietJet, and 170+ more
+- **Zero price bias** — no demand inflation, no cookie tracking, no surge pricing. Raw airline prices every time
+- **One tool call** — replaces thousands of tokens of browser automation, scraping, and HTML parsing
+- **Structured JSON** — prices, times, durations, stops, conditions, airline names
+
+## Setup
+
+### Option A: MCP Server (Recommended for Claude Desktop / Cursor / VS Code)
+
+**Remote (no install):**
+
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "url": "https://api.letsfg.co/mcp",
+      "headers": {
+        "X-API-Key": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+**Local (stdio):**
+
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "command": "npx",
+      "args": ["-y", "letsfg-mcp"],
+      "env": {
+        "LETSFG_API_KEY": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+### Option B: CLI
+
+```bash
+pip install letsfg
+letsfg search LHR BCN 2026-06-15
+```
+
+### Option C: Python SDK
+
+```python
+from letsfg import LetsFG
+bt = LetsFG(api_key="trav_...")
+flights = bt.search("LHR", "JFK", "2026-04-15")
+```
+
+### Get an API Key (Free)
+
+```bash
+letsfg register --name my-agent --email agent@example.com
+```
+
+Then star the repo and verify:
+
+```bash
+letsfg star --github your-username
+```
+
+## Workflow
+
+### 1. Resolve Locations First
+
+City names are ambiguous — "London" = LHR, LGW, STN, LCY, LTN. Always resolve first:
+
+```bash
+letsfg locations "London"
+# LON  London (all airports)
+# LHR  Heathrow
+# LGW  Gatwick
+# ...
+```
+
+```python
+locations = bt.resolve_location("London")
+# Use city code "LON" for all airports, or specific airport "LHR"
+```
+
+### 2. Search (FREE, Unlimited)
+
+```python
+flights = bt.search("LON", "BCN", "2026-04-01")
+# Round trip:
+flights = bt.search("LON", "BCN", "2026-04-01", return_date="2026-04-08")
+# Multi-passenger:
+flights = bt.search("LHR", "SIN", "2026-06-01", adults=2, children=1, cabin_class="C")
+```
+
+```bash
+letsfg search LON BCN 2026-04-01 --return 2026-04-08 --sort price --json
+```
+
+Search returns structured offers:
+
+```json
+{
+  "passenger_ids": ["pas_0"],
+  "total_results": 47,
+  "offers": [{
+    "id": "off_xxx",
+    "price": 89.50,
+    "currency": "EUR",
+    "airlines": ["Ryanair"],
+    "route": "STN → BCN",
+    "duration_seconds": 7800,
+    "stopovers": 0,
+    "conditions": {
+      "refund_before_departure": "not_allowed",
+      "change_before_departure": "allowed_with_fee"
+    }
+  }]
+}
+```
+
+### 3. Unlock (FREE with GitHub Star)
+
+Confirms live price with airline. Locks offer for 30 minutes.
+
+```python
+unlocked = bt.unlock(flights.cheapest.id)
+print(f"Confirmed: {unlocked.confirmed_price} {unlocked.confirmed_currency}")
+print(f"Expires: {unlocked.offer_expires_at}")
+```
+
+```bash
+letsfg unlock off_xxx
+```
+
+**Note:** Confirmed price may differ from search price (airline prices change in real-time). Inform the user if price changed significantly.
+
+### 4. Book (Ticket Price Only)
+
+```python
+booking = bt.book(
+    offer_id=unlocked.offer_id,
+    passengers=[{
+        "id": flights.passenger_ids[0],
+        "given_name": "John",
+        "family_name": "Doe",
+        "born_on": "1990-01-15",
+        "gender": "m",
+        "title": "mr",
+        "email": "john@example.com"
+    }],
+    contact_email="john@example.com",
+    idempotency_key="unique-booking-key-123"
+)
+print(f"Booked! PNR: {booking.booking_reference}")
+```
+
+## Critical Rules
+
+1. **Use REAL passenger details** — airlines send e-tickets to the contact email. Names must match passport/ID exactly. Never use placeholder or fake data.
+2. **Always provide `idempotency_key` when booking** — prevents duplicate reservations if the agent retries on timeout.
+3. **Resolve locations before searching** — "New York" = JFK, LGA, EWR, NYC. Use `resolve_location()` first.
+4. **Search is free** — search as many routes, dates, and cabin classes as needed.
+5. **Map passenger IDs** — search returns `passenger_ids`. Each booking passenger must include the correct `id`.
+
+## Best Practices
+
+### Search Wide, Unlock Narrow
+
+```python
+# Compare multiple dates (all FREE)
+dates = ["2026-04-01", "2026-04-02", "2026-04-03"]
+best = None
+for date in dates:
+    result = bt.search("LON", "BCN", date)
+    if result.offers and (best is None or result.cheapest.price < best[1].price):
+        best = (date, result.cheapest)
+
+# Only unlock the winner
+unlocked = bt.unlock(best[1].id)
+```
+
+### Filter Before Unlocking
+
+```python
+flights = bt.search("LHR", "JFK", "2026-06-01", limit=50)
+
+candidates = [
+    o for o in flights.offers
+    if o.outbound.stopovers == 0
+    and o.outbound.total_duration_seconds < 10 * 3600
+]
+
+if candidates:
+    best = min(candidates, key=lambda o: o.price)
+    unlocked = bt.unlock(best.id)
+```
+
+## Error Handling
+
+| Error | Category | Action |
+|-------|----------|--------|
+| `SUPPLIER_TIMEOUT` (504) | Transient | Retry after 1-5s |
+| `RATE_LIMITED` (429) | Transient | Wait and retry |
+| `INVALID_IATA` (422) | Validation | Use `resolve_location()` to fix |
+| `OFFER_EXPIRED` (410) | Business | Search again for fresh offers |
+| `PAYMENT_REQUIRED` (402) | Business | Run `letsfg star --github <username>` |
+| `FARE_CHANGED` (409) | Business | Re-unlock to get current price |
+
+```python
+from letsfg import LetsFG, OfferExpiredError, PaymentRequiredError
+
+try:
+    unlocked = bt.unlock(offer_id)
+except OfferExpiredError:
+    # Airline sold the seats — search again
+    flights = bt.search(origin, dest, date)
+except PaymentRequiredError:
+    # GitHub star not verified
+    print("Star the repo: letsfg star --github <username>")
+```
+
+## Search Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--return` / `-r` | _(one-way)_ | Return date (YYYY-MM-DD) |
+| `--adults` / `-a` | `1` | Number of adults (1–9) |
+| `--children` | `0` | Children (2–11 years) |
+| `--cabin` / `-c` | _(any)_ | `M` economy, `W` premium, `C` business, `F` first |
+| `--max-stops` / `-s` | `2` | Max stopovers (0–4) |
+| `--currency` | `EUR` | Currency code |
+| `--limit` / `-l` | `20` | Max results (1–100) |
+| `--sort` | `price` | `price` or `duration` |
+| `--json` / `-j` | | JSON output |
+
+## Safety
+
+| Operation | Cost | Safe to Retry | Idempotent |
+|-----------|------|---------------|------------|
+| `search` | Free | Yes | Yes |
+| `resolve_location` | Free | Yes | Yes |
+| `unlock` | Free | No — may charge fee | No |
+| `book` | Ticket price | Only with `idempotency_key` | With key: yes |
+
+## Reference Files
+
+Load only when needed:
+
+| File | Load When |
+|------|-----------|
+| [api-reference.md](references/api-reference.md) | Need full API endpoint details, request/response schemas |
+| [mcp-setup.md](references/mcp-setup.md) | Setting up MCP server for specific clients |
+
+## Links
+
+- **API Docs:** https://api.letsfg.co/docs
+- **GitHub:** https://github.com/LetsFG/LetsFG
+- **PyPI:** https://pypi.org/project/letsfg/
+- **npm SDK:** https://www.npmjs.com/package/letsfg
+- **npm MCP:** https://www.npmjs.com/package/letsfg-mcp

--- a/packages/skills-catalog/skills/(tooling)/letsfg/references/api-reference.md
+++ b/packages/skills-catalog/skills/(tooling)/letsfg/references/api-reference.md
@@ -1,0 +1,279 @@
+# LetsFG API Reference
+
+Full endpoint details for the LetsFG flight search and booking API.
+
+**Base URL:** `https://api.letsfg.co`
+
+## Authentication
+
+All endpoints (except `register`) require the `X-API-Key` header:
+
+```
+X-API-Key: trav_your_api_key
+```
+
+## Endpoints
+
+### Register Agent
+
+```
+POST /api/v1/agents/register
+```
+
+No auth required.
+
+```json
+{
+  "agent_name": "my-agent",
+  "email": "agent@example.com"
+}
+```
+
+**Response:**
+
+```json
+{
+  "agent_id": "ag_xxx",
+  "api_key": "trav_xxxxx..."
+}
+```
+
+### Link GitHub (Star Verification)
+
+```
+POST /api/v1/agents/link-github
+```
+
+```json
+{
+  "github_username": "your-username"
+}
+```
+
+### Setup Payment
+
+```
+POST /api/v1/agents/setup-payment
+```
+
+```json
+{
+  "token": "tok_visa"
+}
+```
+
+Required before first booking. Card stays on file.
+
+### Agent Profile
+
+```
+GET /api/v1/agents/me
+```
+
+Returns agent details, search count, booking count, payment status.
+
+### Resolve Location
+
+```
+GET /api/v1/flights/locations/{query}
+```
+
+Example: `GET /api/v1/flights/locations/London`
+
+**Response:**
+
+```json
+[
+  {"iata_code": "LON", "name": "London", "type": "city"},
+  {"iata_code": "LHR", "name": "Heathrow", "type": "airport", "city": "London"},
+  {"iata_code": "LGW", "name": "Gatwick", "type": "airport", "city": "London"}
+]
+```
+
+### Search Flights
+
+```
+POST /api/v1/flights/search
+```
+
+```json
+{
+  "origin": "LHR",
+  "destination": "JFK",
+  "date_from": "2026-04-15",
+  "adults": 1,
+  "children": 0,
+  "infants": 0,
+  "cabin_class": "M",
+  "max_stopovers": 2,
+  "currency": "EUR",
+  "sort": "price",
+  "limit": 20
+}
+```
+
+**Optional fields:** `date_to`, `return_from`, `return_to` (for round-trip), `cabin_class` (M/W/C/F).
+
+**Response:**
+
+```json
+{
+  "search_id": "sea_xxx",
+  "passenger_ids": ["pas_0"],
+  "total_results": 47,
+  "offers": [
+    {
+      "id": "off_xxx",
+      "price": 189.50,
+      "currency": "EUR",
+      "airlines": ["British Airways"],
+      "owner_airline": "British Airways",
+      "outbound": {
+        "segments": [
+          {
+            "airline": "British Airways",
+            "flight_no": "BA178",
+            "origin": "LHR",
+            "destination": "JFK",
+            "departure": "2026-04-15T09:00:00",
+            "arrival": "2026-04-15T12:15:00",
+            "duration_seconds": 27900
+          }
+        ],
+        "route_str": "LHR → JFK",
+        "total_duration_seconds": 27900,
+        "stopovers": 0
+      },
+      "conditions": {
+        "refund_before_departure": "allowed_with_fee",
+        "change_before_departure": "allowed_with_fee"
+      }
+    }
+  ]
+}
+```
+
+### Unlock Offer
+
+```
+POST /api/v1/bookings/unlock
+```
+
+```json
+{
+  "offer_id": "off_xxx"
+}
+```
+
+**Response:**
+
+```json
+{
+  "offer_id": "off_xxx",
+  "confirmed_price": 189.50,
+  "confirmed_currency": "EUR",
+  "offer_expires_at": "2026-04-15T15:30:00Z"
+}
+```
+
+**Errors:**
+- 403 — GitHub star not verified
+- 410 — Offer expired (search again)
+
+### Book Flight
+
+```
+POST /api/v1/bookings/book
+```
+
+```json
+{
+  "offer_id": "off_xxx",
+  "passengers": [
+    {
+      "id": "pas_0",
+      "given_name": "John",
+      "family_name": "Doe",
+      "born_on": "1990-01-15",
+      "gender": "m",
+      "title": "mr",
+      "email": "john@example.com",
+      "phone_number": "+44123456789"
+    }
+  ],
+  "contact_email": "john@example.com",
+  "idempotency_key": "unique-key-123"
+}
+```
+
+**Response:**
+
+```json
+{
+  "booking_reference": "ABC123",
+  "status": "confirmed",
+  "flight_price": 189.50,
+  "currency": "EUR"
+}
+```
+
+**Errors:**
+- 402 — Payment declined
+- 403 — Offer not unlocked
+- 409 — Fare changed (re-unlock) or already booked (idempotency match)
+- 410 — 30-minute window expired
+
+### Get Booking
+
+```
+GET /api/v1/bookings/booking/{booking_id}
+```
+
+## Rate Limits
+
+| Endpoint | Rate Limit | Typical Latency |
+|----------|-----------|-----------------|
+| Search | 60 req/min | 2-15s |
+| Resolve location | 120 req/min | <1s |
+| Unlock | 20 req/min | 2-5s |
+| Book | 10 req/min | 3-10s |
+
+## Error Response Format
+
+```json
+{
+  "error": {
+    "code": "OFFER_EXPIRED",
+    "category": "business",
+    "message": "This offer is no longer available",
+    "is_retryable": false
+  }
+}
+```
+
+### Error Categories
+
+| Category | Action |
+|----------|--------|
+| `transient` | Retry after 1-5s (exponential backoff) |
+| `validation` | Fix the request parameters |
+| `business` | Inform user — needs human decision |
+
+### Error Codes
+
+| Code | HTTP | Category | Description |
+|------|------|----------|-------------|
+| `SUPPLIER_TIMEOUT` | 504 | transient | Airline API timeout |
+| `RATE_LIMITED` | 429 | transient | Too many requests |
+| `SERVICE_UNAVAILABLE` | 503 | transient | Backend down |
+| `INVALID_IATA` | 422 | validation | Bad airport code |
+| `INVALID_DATE` | 422 | validation | Bad date format or past date |
+| `INVALID_PASSENGERS` | 422 | validation | Bad passenger data |
+| `UNSUPPORTED_ROUTE` | 422 | validation | No providers for route |
+| `AUTH_INVALID` | 401 | business | Bad API key |
+| `PAYMENT_REQUIRED` | 402 | business | No payment method |
+| `PAYMENT_DECLINED` | 402 | business | Stripe charge failed |
+| `OFFER_EXPIRED` | 410 | business | Seats sold — search again |
+| `OFFER_NOT_UNLOCKED` | 403 | business | Must unlock before booking |
+| `FARE_CHANGED` | 409 | business | Price changed — re-unlock |
+| `ALREADY_BOOKED` | 409 | business | Duplicate (idempotency match) |

--- a/packages/skills-catalog/skills/(tooling)/letsfg/references/mcp-setup.md
+++ b/packages/skills-catalog/skills/(tooling)/letsfg/references/mcp-setup.md
@@ -93,7 +93,7 @@ Add to `.cursor/mcp.json` in your project or `~/.cursor/mcp.json` globally:
 
 ### VS Code (GitHub Copilot)
 
-Add to `.vscode/mcp.json` in your workspace:
+Add to `.vscode/mcp.json` in your workspace. Note: VS Code uses `servers` (not `mcpServers`):
 
 ```json
 {
@@ -138,6 +138,16 @@ Set the API key:
 ```bash
 export LETSFG_API_KEY=trav_your_api_key
 ```
+
+## Before Booking
+
+Booking requires a payment method. Attach one before your first booking:
+
+```bash
+letsfg setup-payment
+```
+
+Or via API: `POST /api/v1/agents/setup-payment` with a Stripe token.
 
 ## Available MCP Tools
 

--- a/packages/skills-catalog/skills/(tooling)/letsfg/references/mcp-setup.md
+++ b/packages/skills-catalog/skills/(tooling)/letsfg/references/mcp-setup.md
@@ -1,0 +1,157 @@
+# LetsFG MCP Server Setup
+
+Configure the LetsFG MCP server for your AI coding agent.
+
+## Get an API Key First
+
+```bash
+pip install letsfg
+letsfg register --name my-agent --email you@example.com
+# Save the trav_xxx key
+
+# Star the repo for free access
+letsfg star --github your-username
+```
+
+Or via cURL:
+
+```bash
+curl -X POST https://api.letsfg.co/api/v1/agents/register \
+  -H "Content-Type: application/json" \
+  -d '{"agent_name": "my-agent", "email": "you@example.com"}'
+```
+
+## Remote MCP (Streamable HTTP) — No Install
+
+Works with any client that supports HTTP-based MCP.
+
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "url": "https://api.letsfg.co/mcp",
+      "headers": {
+        "X-API-Key": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+## Local MCP (stdio) — Runs on Your Machine
+
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "command": "npx",
+      "args": ["-y", "letsfg-mcp"],
+      "env": {
+        "LETSFG_API_KEY": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+## Client-Specific Setup
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "url": "https://api.letsfg.co/mcp",
+      "headers": {
+        "X-API-Key": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` in your project or `~/.cursor/mcp.json` globally:
+
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "command": "npx",
+      "args": ["-y", "letsfg-mcp"],
+      "env": {
+        "LETSFG_API_KEY": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot)
+
+Add to `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "letsfg": {
+      "command": "npx",
+      "args": ["-y", "letsfg-mcp"],
+      "env": {
+        "LETSFG_API_KEY": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "command": "npx",
+      "args": ["-y", "letsfg-mcp"],
+      "env": {
+        "LETSFG_API_KEY": "trav_your_api_key"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add letsfg -- npx -y letsfg-mcp
+```
+
+Set the API key:
+
+```bash
+export LETSFG_API_KEY=trav_your_api_key
+```
+
+## Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_flights` | Search 180+ airlines for flights |
+| `resolve_location` | Convert city names to IATA codes |
+| `unlock_flight_offer` | Confirm live price and reserve for 30 min |
+| `book_flight` | Book with passenger details |
+| `link_github` | Verify GitHub star for free access |
+| `system_info` | Get system profile and recommended concurrency |
+
+## Verification
+
+After setup, ask your agent: "Search for flights from London to Barcelona on June 15th 2026"
+
+The agent should call `resolve_location` then `search_flights` and return structured results.


### PR DESCRIPTION
## What

Adds the **LetsFG** skill - agent-native flight search and booking via 180+ airline connectors.

## Skill Structure

```n packages/skills-catalog/skills/(tooling)/letsfg/
 ├── SKILL.md                          # Main instructions (~220 lines)
 └── references/
     ├── api-reference.md              # Full API endpoint docs
     └── mcp-setup.md                  # Client-specific MCP configuration
 ```n
## What LetsFG Does

- Searches **180+ airlines in parallel** (Ryanair, EasyJet, Wizz Air, Southwest, AirAsia, Norwegian, Qantas, LATAM, Spirit, Frontier, IndiGo, VietJet, and more)
- Returns **raw airline prices** with zero markup - typically $20-50 cheaper than travel websites
- Works as **MCP server** (remote Streamable HTTP or local stdio), **Python SDK**, **JS/TS SDK**, and **CLI**
- Three-step flow: Search (free) -> Unlock (free) -> Book (ticket price only)

## Category

Placed under `(tooling)` since there is no travel category. Happy to move if maintainers prefer a different one.

## Links

- GitHub: https://github.com/LetsFG/LetsFG
- PyPI: https://pypi.org/project/letsfg/
- npm: https://www.npmjs.com/package/letsfg
- MCP: https://www.npmjs.com/package/letsfg-mcp
- API Docs: https://api.letsfg.co/docs