### PR TITLE
fix: add missing version field to MCP plugin.json

### DIFF
--- a/packages/mcp/.claude-plugin/plugin.json
+++ b/packages/mcp/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-skills-mcp",
   "description": "The official MCP for agent-skills. Curated catalog, progressive disclosure flow: Search → load canonical SKILL.md → fetch only validated references. Safe, lean, zero config.",
+  "version": "0.1.3",
   "author": { "name": "Tech Leads Club" }
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The `packages/mcp/.claude-plugin/plugin.json` file is missing the required `version` field. The Claude Code plugin registry uses `version` for install, update, and conflict resolution — without it, plugin deduplication is broken and upgrades may not apply correctly.

## Fix

Added `"version": "0.1.3"` to mirror the version already declared in `packages/mcp/package.json`. The field is placed after `description` and before `author` for logical grouping.

## Diff

```json
{
  "name": "agent-skills-mcp",
  "description": "...",
+ "version": "0.1.3",
  "author": { "name": "Tech Leads Club" }
}
```

This is a single-line addition with no behavioral changes to existing functionality.