### PR TITLE
fix(security): make Chromium --no-sandbox conditional on env var

### DIFF
--- a/packages/skills-catalog/skills/(web-automation)/playwright-skill/lib/helpers.js
+++ b/packages/skills-catalog/skills/(web-automation)/playwright-skill/lib/helpers.js
@@ -41,10 +41,16 @@ function getExtraHeadersFromEnv() {
  * @param {Object} options - Additional launch options
  */
 async function launchBrowser(browserType = 'chromium', options = {}) {
+  // '--no-sandbox' is required in CI/Docker environments where the user namespace
+  // is not available. For local interactive use the sandbox should stay enabled.
+  // Set PLAYWRIGHT_NO_SANDBOX=1 to opt in (e.g. in CI configuration).
+  const sandboxArgs = process.env.PLAYWRIGHT_NO_SANDBOX === '1'
+    ? ['--no-sandbox', '--disable-setuid-sandbox']
+    : [];
   const defaultOptions = {
     headless: process.env.HEADLESS !== 'false',
     slowMo: process.env.SLOW_MO ? parseInt(process.env.SLOW_MO) : 0,
-    args: ['--no-sandbox', '--disable-setuid-sandbox']
+    args: sandboxArgs
   };
   
   const browsers = { chromium, firefox, webkit };


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low severity)

`playwright-skill/lib/helpers.js` always passes `--no-sandbox` and `--disable-setuid-sandbox` to Chromium. While this is necessary in CI/Docker environments (where user namespaces are unavailable), it unnecessarily reduces browser isolation during local interactive use — particularly relevant when the automation navigates attacker-controlled URLs.

## Fix

The sandbox flags are now conditional on the `PLAYWRIGHT_NO_SANDBOX=1` environment variable:

```js
const sandboxArgs = process.env.PLAYWRIGHT_NO_SANDBOX === '1'
  ? ['--no-sandbox', '--disable-setuid-sandbox']
  : [];
```

**For CI users**: add `PLAYWRIGHT_NO_SANDBOX=1` to your CI environment to restore existing behaviour.  
**For local users**: no change required — the full sandbox is now active by default.

This change has no effect on the skill's functionality; it only changes when the sandbox is disabled.