### PR TITLE
docs(security): warn against building inline exec strings from untrusted input

### DIFF
--- a/packages/skills-catalog/skills/(web-automation)/playwright-skill/SKILL.md
+++ b/packages/skills-catalog/skills/(web-automation)/playwright-skill/SKILL.md
@@ -299,6 +299,12 @@ await browser.close();
 - **Inline**: Quick one-off tasks (screenshot, check if element exists, get page title)
 - **Files**: Complex tests, responsive design checks, anything user might want to re-run
 
+> **Security note**: The inline execution path passes a code string as a shell argument.
+> Never construct that string from external web content, scraped page text, or
+> unsanitized user input — shell metacharacters or injected statements would execute
+> with full Node.js privileges. See also the `SECURITY WARNING` block at the bottom
+> of this file regarding untrusted web content.
+
 ## Available Helpers
 
 Optional utility functions in `lib/helpers.js`:


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium severity)

The "Inline Execution (Simple Tasks)" section of `playwright-skill/SKILL.md` shows how to pass a code string as a shell argument to `node run.js "..."`. The section has no warning about input sources, even though constructing that string from external web content or unsanitized user input would allow shell metacharacter injection or arbitrary code execution with full Node.js privileges.

The file already has an excellent `SECURITY WARNING` block at the bottom covering prompt injection from web pages — but that warning is spatially distant from the inline execution examples where the risk is most acute.

## Fix

Added a blockquote security note immediately after the "when to use inline vs files" bullet list — directly adjacent to the code examples — warning that the code string must never be constructed from external or unsanitized input, and cross-referencing the existing `SECURITY WARNING`.

No code changes. Documentation only.