### PR TITLE
fix(security): allow VERCEL_DEPLOY_ENDPOINT to override hard-coded deploy server URL

### DIFF
--- a/packages/skills-catalog/skills/(cloud)/vercel-deploy/scripts/deploy.sh
+++ b/packages/skills-catalog/skills/(cloud)/vercel-deploy/scripts/deploy.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-DEPLOY_ENDPOINT="https://deploy-skills.vercel.sh/api/deploy"
+DEPLOY_ENDPOINT="${VERCEL_DEPLOY_ENDPOINT:-https://deploy-skills.vercel.sh/api/deploy}"
 
 # Detect framework from package.json
 detect_framework() {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low severity)

`vercel-deploy/scripts/deploy.sh` hard-codes the deployment endpoint as `https://deploy-skills.vercel.sh/api/deploy`. This creates a third-party dependency — if that server is unavailable, compromised, or needs to be pointed at an internal mirror, there is currently no way to do so without modifying the script.

## Fix

One-line change to read from an environment variable with the original URL as the default:

```bash
- DEPLOY_ENDPOINT="https://deploy-skills.vercel.sh/api/deploy"
+ DEPLOY_ENDPOINT="${VERCEL_DEPLOY_ENDPOINT:-https://deploy-skills.vercel.sh/api/deploy}"
```

**Existing behaviour is unchanged** — if `VERCEL_DEPLOY_ENDPOINT` is not set, the original URL is used. Operators who want to point to an internal mirror or a pinned version of the service can now do so without patching the script.