### PR TITLE
feat: add Odoo ERP skills

### DIFF
--- a/packages/skills-catalog/skills/(erp)/odoo-accounting-inspect/SKILL.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-accounting-inspect/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: odoo-accounting-inspect
+description: "Inspect Odoo accounting: invoices, bills, payments, journal entries, aged receivables. READ-ONLY. WHEN: invoice, bill, payment, overdue, unpaid, posted, draft invoice, receivable, payable, journal entry, aged, account.move. DO NOT USE WHEN: posting invoices, creating payments, or reconciling — use the write tier."
+license: MIT
+metadata:
+  author: oconsole
+  version: "1.0.0"
+  tier: read
+---
+
+# Odoo Accounting Inspect (read-only)
+
+> **READ-ONLY.** This skill never calls mutating tools.
+
+## Key field names (Odoo 17+)
+
+| Model | Wrong name | Correct name |
+|---|---|---|
+| `account.move` | `type` | `move_type` (renamed in Odoo 16) |
+| `account.move` | `post_date`, `posted_date` | `invoice_date` (for invoice date) or `date` (for accounting date) |
+| `account.move` | `invoice_due_date` | verify via `odoo_get_fields(model='account.move')` |
+| `account.payment` | `payment_date` | `date` |
+
+## Recipes
+
+### Customer invoices (posted, recent)
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("account.move", "search_read", ...)`
+
+```
+cutoff = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
+
+odoo_search_read(model="account.move",
+  domain=[
+    ["move_type","=","out_invoice"],
+    ["state","=","posted"],
+    ["invoice_date",">",cutoff]
+  ],
+  fields=["name","partner_id","invoice_date","amount_total","amount_residual","state","payment_state"],
+  limit=200, order="invoice_date desc")
+```
+
+> The field is `move_type` — NEVER use `type`. Values: `out_invoice` (customer invoice), `in_invoice` (vendor bill), `out_refund`, `in_refund`, `entry` (journal entry).
+> NEVER use `%(date)s` or `now()` in domains — compute dates in Python first.
+
+### Unpaid / overdue invoices
+
+```
+odoo_search_read(model="account.move",
+  domain=[
+    ["move_type","in",["out_invoice","out_refund"]],
+    ["state","=","posted"],
+    ["payment_state","in",["not_paid","partial"]]
+  ],
+  fields=["name","partner_id","invoice_date","invoice_date_due","amount_total","amount_residual"],
+  limit=200, order="invoice_date_due asc")
+```
+
+> `payment_state` values: `not_paid`, `partial`, `paid`, `in_payment`, `reversed`.
+> `amount_residual` = the amount still owed.
+> To check "overdue": compare `invoice_date_due` < today (compute today's date in Python).
+
+### Vendor bills
+
+```
+odoo_search_read(model="account.move",
+  domain=[["move_type","=","in_invoice"],["state","=","draft"]],
+  fields=["name","partner_id","invoice_date","amount_total","ref"],
+  limit=100, order="invoice_date desc")
+```
+
+### Payments
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("account.payment", "search_read", ...)`
+
+```
+odoo_search_read(model="account.payment",
+  domain=[["state","=","posted"]],
+  fields=["name","partner_id","amount","date","payment_type","journal_id"],
+  limit=100, order="date desc")
+```
+
+> The date field is `date` — NEVER use `payment_date`.
+> `payment_type`: `inbound` (customer payment), `outbound` (vendor payment).
+
+### Invoice counts by state
+
+**MCP tool:** `odoo_search_count` (multiple calls)
+**Raw RPC:** `execute("account.move", "search_count", ...)`
+
+```
+# Count by move_type × state
+for move_type in ["out_invoice", "in_invoice", "entry"]:
+    for state in ["draft", "posted", "cancel"]:
+        odoo_search_count(
+          model="account.move",
+          domain=[["move_type","=",move_type],["state","=",state]])
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/SKILL.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: odoo-model-customize-demo
+description: "Sandboxed Odoo model customization for learning, prototyping, and demos. Same operations as odoo-model-customize (set defaults, create custom fields, modify views, build automations, save filters) BUT every artifact is tagged as demo data so it can be cleanly rolled back. WHEN: try, demo, prototype, experiment, sandbox, learn, walk me through, test out, see how it works. DO NOT USE WHEN: the user is operating on a production database and wants real persistent changes — switch to odoo-model-customize."
+license: MIT
+metadata:
+  author: oconsole
+  version: "1.0.0"
+  tier: demo
+---
+
+# Odoo Model Customize — Demo Mode
+
+> **DEMO TAGGING IS MANDATORY.** Every record this skill creates or mutates MUST be identifiable as demo data so it can be found and removed. The `[DEMO]` prefix on names, the `x_demo_` prefix on custom fields, and the `.demo.` infix on views are non-negotiable. If you cannot tag the artifact, do not create it.
+
+> **WHEN IN DOUBT, REFUSE.** This skill is for sandbox / demo / prototyping work. If the user is on a production database and wants permanent changes, stop and tell them to install the `odoo-skills-write` plugin and use the `odoo-model-customize` skill instead.
+
+## Triggers
+
+Activate this skill when the user wants to:
+- Try out Odoo customization features without committing to anything
+- See a demo of how custom fields, views, automations, or filters work
+- Prototype an idea on a sandbox/demo Odoo instance
+- Walk through what's possible at runtime without writing a module
+- Experiment safely before promoting changes to production
+
+## Compatibility — Odoo 18 and Odoo 19
+
+Verified on **Odoo 18.0** and **Odoo 19.0**. The runtime customization API is identical between the two versions; the demo guardrails below apply equally to both. See `references/safety-boundary.md` for the version-by-version field reference.
+
+---
+
+## Demo Tagging Conventions
+
+Every artifact you create gets a discriminator that makes it trivially findable later. Use these exact prefixes:
+
+| Artifact | Convention | Example |
+|---|---|---|
+| Custom field on a model | `x_demo_<purpose>` (NOT `x_<purpose>`) | `x_demo_priority`, `x_demo_notes` |
+| Inherited view | `<model>.<viewtype>.demo.<purpose>` | `res.partner.form.demo.priority_field` |
+| Saved filter (`ir.filters`) | `[DEMO] <name>` | `[DEMO] Active Customers` |
+| Automation (`base.automation`) | `[DEMO] <name>` | `[DEMO] Auto-tag VIPs` |
+| Server action (`ir.actions.server`) | `[DEMO] <name>` | `[DEMO] Set priority high` |
+| `ir.default` value | scope to a demo user or company if possible | `user_id=<demo_user>` |
+| Window action mods | NEVER modify global window actions in demo mode — duplicate first or skip |
+
+If a user asks to modify a global window action (`ir.actions.act_window`) in demo mode, REFUSE. Window actions are global UI state; mutating them in a demo session leaks into production. Direct them to the write tier or suggest creating a saved filter instead, which is per-user/scoped.
+
+---
+
+## Allowed vs Restricted Operations
+
+| Operation | Demo mode? | How |
+|---|---|---|
+| Set field defaults via `ir.default` | ALLOWED, scope to a demo `user_id` if available | `odoo_set_default(model, field, value, user_id=<demo_user_id>)` |
+| Create custom field on a model | ALLOWED with `x_demo_` prefix | `odoo_create("ir.model.fields", {name: "x_demo_priority", state: "manual", ...})` |
+| Inherit a view to add a field | ALLOWED with `.demo.` infix in name | `odoo_create("ir.ui.view", {name: "res.partner.form.demo.priority", ...})` |
+| Create a saved filter | ALLOWED with `[DEMO]` prefix | `odoo_create("ir.filters", {name: "[DEMO] Active VIPs", ...})` |
+| Create an automated action | ALLOWED with `[DEMO]` prefix on both action and trigger | `odoo_create("base.automation", {name: "[DEMO] ...", ...})` |
+| Modify a shared `ir.actions.act_window` | **REFUSED** — too global for demo mode | Suggest a saved filter instead |
+| Delete production records | **REFUSED** | Demo mode never deletes user data |
+| Change field types or rename fields | **REFUSED** — destructive and irreversible | — |
+
+## Rules
+
+1. **Discover first.** Always run `odoo_model_info(model)` before creating anything, exactly like the production skill.
+2. **Tag every artifact** with the conventions above. No exceptions.
+3. **Show the user the cleanup recipe** at the end of every session, so they know how to remove what you created.
+4. **Confirm before deleting.** Even cleanup of demo records gets one confirmation.
+5. **Never touch production-named records.** If a record matches the user's question but doesn't have a demo tag (e.g., they say "modify the Quotations action"), refuse and explain that demo mode operates on `[DEMO]`-tagged artifacts only.
+6. **Verify after every write.** Re-read the record using a `[DEMO]`-anchored domain to confirm.
+
+---
+
+## Steps
+
+| # | Action | Tool |
+|---|--------|------|
+| 1 | **Discover** — get model shape | `odoo_model_info` |
+| 2 | **Plan the demo artifact** — pick a name with the demo prefix | — |
+| 3 | **Create** — with the demo prefix baked in | `odoo_create` / `odoo_set_default` |
+| 4 | **Verify** — re-read using a domain that matches the demo prefix | `odoo_search_read` |
+| 5 | **Report** — show what was created and the cleanup recipe | — |
+
+---
+
+## Example: Add a "Priority" Custom Field on Demo
+
+```
+# 1. Get the model_id
+odoo_model_info(model="res.partner")
+# → ir.model id = 42
+
+# 2. Create custom field with demo prefix
+odoo_create(model="ir.model.fields", values={
+    "model_id": 42,
+    "name": "x_demo_priority",          # x_demo_, NOT x_
+    "field_description": "[DEMO] Priority",
+    "ttype": "selection",
+    "state": "manual",
+    "selection_ids": [
+        [0, 0, {"value": "low",    "name": "Low",    "sequence": 1}],
+        [0, 0, {"value": "medium", "name": "Medium", "sequence": 2}],
+        [0, 0, {"value": "high",   "name": "High",   "sequence": 3}],
+    ]
+})
+
+# 3. Add it to the form via a demo-named inherited view
+odoo_create(model="ir.ui.view", values={
+    "name": "res.partner.form.demo.priority",   # .demo. infix
+    "model": "res.partner",
+    "inherit_id": <base_partner_form_id>,
+    "priority": 99,
+    "arch": "<data><xpath expr=\"//field[@name='phone']\" position=\"after\"><field name=\"x_demo_priority\"/></xpath></data>"
+})
+
+# 4. Verify
+odoo_search_read(model="ir.model.fields",
+    domain=[["name","=","x_demo_priority"],["model","=","res.partner"]],
+    fields=["name","field_description","ttype","state"],
+    limit=1)
+```
+
+Then ALWAYS show the user the cleanup recipe.
+
+---
+
+## Cleanup Recipe (always show this at the end of a demo session)
+
+To remove everything this demo session created, run these queries to find demo artifacts and delete them. Always confirm with the user before deleting.
+
+```
+# Custom fields with x_demo_ prefix
+odoo_search_read(model="ir.model.fields",
+    domain=[["name","=like","x_demo_%"],["state","=","manual"]],
+    fields=["id","name","model","field_description"], limit=200)
+
+# Inherited views with .demo. in the name
+odoo_search_read(model="ir.ui.view",
+    domain=[["name","like",".demo."]],
+    fields=["id","name","model"], limit=200)
+
+# Saved filters
+odoo_search_read(model="ir.filters",
+    domain=[["name","=like","[DEMO]%"]],
+    fields=["id","name","model_id"], limit=200)
+
+# Automations
+odoo_search_read(model="base.automation",
+    domain=[["name","=like","[DEMO]%"]],
+    fields=["id","name","model_id"], limit=200)
+
+# Server actions
+odoo_search_read(model="ir.actions.server",
+    domain=[["name","=like","[DEMO]%"]],
+    fields=["id","name","model_id"], limit=200)
+```
+
+After confirming with the user, delete in this order (children first):
+
+1. `base.automation` (depends on `ir.actions.server`)
+2. `ir.actions.server`
+3. `ir.ui.view` (so the field isn't referenced when deleted)
+4. `ir.filters`
+5. `ir.model.fields` (last — destroys the column data)
+
+> **Cleanup of `ir.model.fields` is destructive** and removes the column from the database. Confirm explicitly with the user even in demo mode.
+
+---
+
+## What This Skill Does Not Cover
+
+| Operation | Why | Where to go |
+|---|---|---|
+| Production model customization | Demo mode is sandbox-only | `odoo-skills-write` plugin → `odoo-model-customize` |
+| Reading / inspecting / auditing data | No writes needed | `odoo-skills-read` plugin → `odoo-model-inspect` |
+| Modifying global window actions | Bleeds into production state | Use a saved filter instead |
+| Creating Python modules / Python inheritance | Runtime can't do this in any tier | Use the `odoo-19` development skill |

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/automation.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/automation.md
@@ -1,0 +1,92 @@
+# Automated Actions (base.automation)
+
+> **Odoo 18 & 19:** `base.automation` and `ir.actions.server` schemas are identical in both versions. Trigger types (`on_create`, `on_write`, `on_create_or_write`, `on_unlink`, `on_time`) are unchanged. `ir.actions.server.state` values (`object_write`, `email`, `followers`, `next_activity`, `code`, `multi`) are the same. The `code` action requires admin in both. Trigger field linkage uses the same `[[6, 0, [...]]]` Many2many command syntax in both.
+
+## What They Are
+
+Automated actions trigger server actions when records are created, updated, deleted, or based on a time condition. They're stored in `base.automation` and don't require a custom module.
+
+## Prerequisites
+
+The `base_automation` module must be installed. Check with:
+
+```
+odoo_search_read(model="ir.module.module", domain=[["name","=","base_automation"],["state","=","installed"]], fields=["name","state"], limit=1)
+```
+
+## Creating an Automated Action
+
+### Step 1: Create a Server Action
+
+The server action defines what happens when triggered.
+
+```
+# Get the model ID first
+odoo_search_read(model="ir.model", domain=[["model","=","res.partner"]], fields=["id"], limit=1)
+# Returns: {"records": [{"id": 42}]}
+
+# Create a server action that updates a field
+odoo_create(model="ir.actions.server", values={
+    "name": "Set Priority to High for Large Companies",
+    "model_id": 42,
+    "state": "object_write",
+    "update_field_id": FIELD_ID_OF_X_PRIORITY,
+    "update_m2m_operation": "set",
+    "value": "high"
+})
+```
+
+### Step 2: Create the Automation Trigger
+
+```
+# Trigger when partner is created
+odoo_create(model="base.automation", values={
+    "name": "Auto-set priority for new partners",
+    "model_id": 42,
+    "trigger": "on_create",
+    "action_server_ids": [[6, 0, [SERVER_ACTION_ID]]]
+})
+
+# Trigger when email field changes
+odoo_create(model="base.automation", values={
+    "name": "Log email changes",
+    "model_id": 42,
+    "trigger": "on_write",
+    "trigger_field_ids": [[6, 0, [EMAIL_FIELD_ID]]],
+    "action_server_ids": [[6, 0, [SERVER_ACTION_ID]]]
+})
+```
+
+## Trigger Types
+
+| Trigger | When it fires |
+|---------|---------------|
+| `on_create` | When a new record is created |
+| `on_write` | When specified fields are modified |
+| `on_create_or_write` | On both create and write |
+| `on_unlink` | When a record is deleted |
+| `on_time` | Based on a date field + interval |
+
+## Server Action Types
+
+| state | What it does |
+|-------|-------------|
+| `object_write` | Update field values on the record |
+| `email` | Send an email |
+| `followers` | Add/remove followers |
+| `next_activity` | Schedule an activity |
+| `code` | Execute Python code (requires admin) |
+| `multi` | Run multiple actions in sequence |
+
+## Common Use Cases
+
+- **Auto-tag new records** — on_create → set a field value
+- **Notify on changes** — on_write → send email
+- **Escalation** — on_time (e.g., 3 days after create_date) → send email or update field
+- **Data validation** — on_create_or_write → code action that checks conditions
+
+## Listing Existing Automations
+
+```
+odoo_search_read(model="base.automation", domain=[], fields=["name","model_id","trigger","active"], limit=50)
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/custom-fields.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/custom-fields.md
@@ -1,0 +1,99 @@
+# Creating Custom Fields at Runtime
+
+> **Odoo 18 & 19:** `ir.model.fields` accepts identical create payloads in both versions. The `state="manual"` + `x_` prefix rules are unchanged. Selection field creation via `selection_ids` (a One2many to `ir.model.fields.selection`) works the same in both. The supported `ttype` values are identical.
+
+## How it Works
+
+Odoo allows creating "manual" fields at runtime by writing to `ir.model.fields`. These fields:
+- **Must** have names starting with `x_`
+- **Must** have `state = "manual"`
+- Are immediately available for use in views and searches
+- Survive module upgrades (they're stored in the database, not in Python code)
+- This is exactly how Odoo Studio creates fields
+
+## Creating a Custom Field
+
+### Simple text field
+
+```
+# First, get the model's ir.model ID
+odoo_search_read(model="ir.model", domain=[["model","=","res.partner"]], fields=["id"], limit=1)
+# Returns: {"records": [{"id": 42}]}
+
+# Create the field
+odoo_create(model="ir.model.fields", values={
+    "model_id": 42,
+    "name": "x_internal_notes",
+    "field_description": "Internal Notes",
+    "ttype": "text",
+    "state": "manual"
+})
+```
+
+### Selection field
+
+```
+odoo_create(model="ir.model.fields", values={
+    "model_id": 42,
+    "name": "x_priority_level",
+    "field_description": "Priority Level",
+    "ttype": "selection",
+    "state": "manual",
+    "selection_ids": [
+        [0, 0, {"value": "low", "name": "Low", "sequence": 1}],
+        [0, 0, {"value": "medium", "name": "Medium", "sequence": 2}],
+        [0, 0, {"value": "high", "name": "High", "sequence": 3}]
+    ]
+})
+```
+
+### Many2one (relational) field
+
+```
+odoo_create(model="ir.model.fields", values={
+    "model_id": 42,
+    "name": "x_project_id",
+    "field_description": "Related Project",
+    "ttype": "many2one",
+    "relation": "project.project",
+    "state": "manual"
+})
+```
+
+## Supported Field Types
+
+| ttype | Description | Extra params |
+|-------|-------------|-------------|
+| `char` | Short text | `size` (optional max length) |
+| `text` | Long text | — |
+| `integer` | Whole number | — |
+| `float` | Decimal number | `digits` (optional precision) |
+| `boolean` | True/False | — |
+| `date` | Date only | — |
+| `datetime` | Date + time | — |
+| `selection` | Dropdown | `selection_ids` (required) |
+| `many2one` | Link to another record | `relation` (target model name) |
+| `many2many` | Multiple links | `relation` (target model name) |
+| `binary` | File upload | — |
+| `html` | Rich text | — |
+
+## After Creating the Field
+
+The field exists in the database but is **not visible in any view** until you add it. See [View Inheritance Guide](view-inheritance.md) to add it to a form or tree view.
+
+## Deleting a Custom Field
+
+```
+# Find the field
+odoo_search_read(model="ir.model.fields", domain=[["model","=","res.partner"],["name","=","x_internal_notes"]], fields=["id"], limit=1)
+
+# Delete it (WARNING: destroys all data in that field)
+odoo_delete(model="ir.model.fields", ids=[FIELD_ID])
+```
+
+## Rules
+
+- **Always use x_ prefix** — fields without it are rejected
+- **Always set state='manual'** — this marks it as user-created
+- **Verify the model_id** — use odoo_model_info to get the correct ir.model ID
+- **Selection values must have both value and name** — value is the technical key, name is the display label

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/defaults.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/defaults.md
@@ -1,0 +1,121 @@
+# Setting Field Defaults
+
+> **Odoo 18 & 19:** the `ir.default` schema is **identical in both versions** — same columns (`field_id`, `user_id`, `company_id`, `condition`, `json_value`), same `set()` API, same JSON encoding. `ir.default` has **no `model_id` or `model` column** in either version, so to filter defaults by model you must traverse the `field_id` Many2one: `[["field_id.model_id.model","=",model_name]]` or the shorter `[["field_id.model","=",model_name]]` (the latter works because `ir.model.fields.model` is a stored Char in both versions).
+
+## Using odoo_set_default
+
+The safest and simplest way to set defaults. Handles JSON encoding and field lookup automatically.
+
+### Set a global default
+
+```
+odoo_set_default(model="product.template", field_name="invoice_policy", value="delivery")
+```
+
+### Set a user-specific default
+
+```
+odoo_set_default(model="sale.order", field_name="warehouse_id", value=2, user_id=5)
+```
+
+### Set a company-specific default
+
+```
+odoo_set_default(model="sale.order", field_name="warehouse_id", value=3, company_id=1)
+```
+
+### Remove a default
+
+```
+odoo_set_default(model="product.template", field_name="invoice_policy", value=null)
+```
+
+## How it Works Internally
+
+The tool:
+1. Finds the `field_id` in `ir.model.fields` (validates the field exists)
+2. JSON-encodes the value with `json.dumps()`
+3. Searches `ir.default` for an existing default matching the field + user + company
+4. Creates or updates the `ir.default` record
+5. Returns before/after values for confirmation
+
+## Value Types
+
+| Field type | Example value | JSON stored as |
+|-----------|---------------|----------------|
+| Char/Text | `"hello"` | `"\"hello\""` |
+| Integer | `42` | `"42"` |
+| Float | `3.14` | `"3.14"` |
+| Boolean | `true` | `"true"` |
+| Selection | `"delivery"` | `"\"delivery\""` |
+| Many2one | `5` | `"5"` (the record ID) |
+| Date | `"2024-01-15"` | `"\"2024-01-15\""` |
+
+## Common Pitfalls
+
+- **Wrong field name**: Use `odoo_model_info` first to confirm the exact field name
+- **Selection values**: Must match the technical key, not the label (e.g., `"delivery"` not `"Based on Delivered Quantity"`)
+- **Many2one**: Pass the integer ID, not a name string
+- **Existing default**: The tool handles update vs create automatically — no need to delete first
+
+
+## Learned from Experience
+
+Complete the truncated "Common Pitfalls" section and add a troubleshooting guide.
+
+```markdown
+## Common Pitfalls
+
+- **Wrong field name**: Use `odoo_model_info` first to confirm the exact field name
+- **Selection values**: Must match the exact selection key (e.g., `"delivery"` not `"Delivery"`)
+- **Many2one IDs**: Use the record ID, not the display name. Verify with `odoo_search_read` first
+- **Date format**: Use ISO format `"YYYY-MM-DD"` for date fields
+- **Null vs empty string**: `null` removes the default; `""` sets an empty string default
+- **User/company context**: Defaults are scoped—a user-specific default overrides global, company-specific overrides global
+
+## Troubleshooting
+
+**Default not appearing in form?**
+- Check if the field has a hardcoded default in the model's Python code (takes precedence)
+- Verify the field name matches exactly (case-sensitive)
+- Confirm the user/company context matches where you're testing
+
+**Value looks wrong in database?**
+- Use `odoo_search_read("ir.default", [["field_id.name", "=", "your_field"]])` to inspect the raw JSON
+- The value is stored JSON-encoded; `"5"` (string) is correct for many2one, not `5` (integer)
+```
+
+---
+
+##
+
+
+## Learned from Experience
+
+Complete the truncated "Common Pitfalls" section and add troubleshooting guidance
+
+```markdown
+## Common Pitfalls
+
+- **Wrong field name**: Use `odoo_model_info` first to confirm the exact field name
+- **Selection values**: Must match the exact string defined in the field's `selection` parameter. Use `odoo_get_fields(model)` to see valid options.
+- **Many2one IDs**: Always use the record ID, not the display name. Verify the ID exists with `odoo_search_read`.
+- **Relational fields**: Cannot set defaults for one2many or many2many fields via `ir.default`. Use server actions or automated actions instead.
+- **User/company context**: If `user_id` or `company_id` is specified, the default only applies to that user/company. Omit both for a global default.
+
+## Troubleshooting
+
+**Default not appearing in form:**
+- Check if the field is already set on the record (defaults only apply to new records)
+- Verify the user/company context matches where you're testing
+- Use `odoo_search_read("ir.default", domain=[("field_id.name", "=", "field_name")])` to confirm the default was created
+
+**"Field not found" error:**
+- Run `odoo_model_info(model)` and check the `custom_fields` and `fields_by_type` sections
+- Ensure you're using the exact field name (case-sensitive)
+- Custom fields must start with `x_`
+```
+
+---
+
+##

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/discovery.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/discovery.md
@@ -1,0 +1,143 @@
+# Model Discovery Guide
+
+## Step 1: Get the Full Picture
+
+Always start with `odoo_model_info(model)` before making any changes. This returns:
+
+```json
+{
+  "model": "sale.order",
+  "name": "Sales Order",
+  "default_order": "date_order desc, id desc",
+  "rec_name": "name",
+  "field_count": 148,
+  "fields_by_type": {"many2one": 25, "char": 18, "float": 12, ...},
+  "custom_fields": [{"name": "x_notes", "type": "text", "label": "Internal Notes"}],
+  "relational_fields": [{"name": "partner_id", "type": "many2one", "target": "res.partner"}],
+  "required_fields": [{"name": "partner_id", "type": "many2one", "label": "Customer"}],
+  "views": [{"id": 944, "name": "sale.order.form", "type": "form", "priority": 16}],
+  "actions": [{"id": 312, "name": "Quotations", "domain": "...", "context": "..."}],
+  "defaults": [{"field": "invoice_policy", "value": "\"order\""}]
+}
+```
+
+## Step 2: Understand What You're Working With
+
+| Field in response | What it tells you |
+|-------------------|-------------------|
+| `default_order` | Current `_order` — **cannot change at runtime** |
+| `rec_name` | Field used for display name in dropdowns |
+| `custom_fields` | Existing x_ fields already on the model |
+| `required_fields` | Fields that are required at model level |
+| `views` | Base views — use their IDs for `inherit_id` |
+| `actions` | Window actions — use their IDs for `odoo_modify_action` |
+| `defaults` | Current ir.default values (JSON-encoded) |
+
+## Step 3: Get View Details (when modifying views)
+
+```
+odoo_get_view(model="sale.order", view_type="form")
+```
+
+Returns the **merged** XML after all inheritance. Use this to:
+- Find the field names used in the view
+- Identify where to insert new fields (XPath targets)
+- See what's already visible/hidden
+
+## Step 4: Get Field Details (when adding/querying fields)
+
+```
+odoo_get_fields(model="sale.order")
+```
+
+Returns all field definitions with type, required, readonly, help text. Use this to:
+- Find the exact field name (not the label)
+- Check field type before setting a default
+- Identify relational field targets
+
+## Odoo 18 / 19 Notes for Discovery
+
+| Item | Odoo 18 | Odoo 19 |
+|---|---|---|
+| `ir.model.order` (stored mirror of `_order`) | Available — safe to read | Available — safe to read |
+| `ir.model.rec_name` | **Does not exist** — never request it | **Does not exist** — never request it |
+| `ir.model.abstract` | Does not exist — querying it errors | Available |
+| `ir.model.fold_name` | Does not exist — querying it errors | Available |
+
+**Safe `ir.model` query that works on BOTH versions:**
+
+```python
+odoo_search_read(
+    model="ir.model",
+    domain=[["model", "=", target_model]],
+    fields=["name", "model", "order", "state", "transient"],
+    limit=1,
+)
+```
+
+**To get `_rec_name`** (since it isn't stored anywhere queryable), inspect `ir.model.fields` for the model and pick `"name"` if it exists, otherwise `"x_name"`, otherwise `"id"`. This is exactly what Odoo itself does.
+
+
+## Learned from Experience
+
+Add a Step 4 section with guidance on interpreting `default_order` and when to use `odoo_modify_action`.
+
+```markdown
+## Step 4: Interpret default_order vs _order
+
+The `default_order` field in the response shows the **current runtime sort order** for that action, not the model's `_order`. 
+
+- If `default_order` is `null` or empty: the list uses the model's `_order` (cannot change at runtime)
+- If `default_order` has a value: that action has already been customized; you can override it with `odoo_modify_action(action_id=..., order="...")`
+
+**Always check which action ID you're modifying** — a model may have multiple window actions (e.g., "Quotations" vs "Sales Orders"), each with different sort orders.
+```
+
+---
+
+##
+
+
+## Learned from Experience
+
+Complete the truncated Step 3 section and add guidance on using `odoo_get_fields` for detailed field discovery
+
+```markdown
+## Step 3: Get View Details (when modifying views)
+
+`odoo_get_view(view_id)` returns the XML structure of a specific view. Use this when:
+- You need to find XPath targets for inherited views
+- You want to understand the current field layout
+- You're planning to hide/show fields or reorder them
+
+## Step 4: Get Detailed Field Information
+
+`odoo_get_fields(model)` returns comprehensive field metadata:
+
+```json
+{
+  "partner_id": {
+    "type": "many2one",
+    "relation": "res.partner",
+    "required": true,
+    "readonly": false,
+    "help": "Customer for this order"
+  },
+  "date_order": {
+    "type": "datetime",
+    "required": true,
+    "readonly": false
+  }
+}
+```
+
+Use this to:
+- Confirm field types before setting defaults
+- Find relational targets (many2one, one2many, many2many)
+- Check if a field is already required at model level
+- Understand field dependencies before creating custom fields
+```
+
+---
+
+##

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/filters.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/filters.md
@@ -1,0 +1,65 @@
+# Default Filters and Grouping
+
+> **Odoo 18 & 19:** `ir.actions.act_window.context` and `domain` are stored as Python-dict / Python-list **strings** in both versions (NOT JSON). `search_default_<filter_name>` and `group_by` context keys behave identically. The set of accepted context keys is the same in both versions.
+
+## Via Window Actions (odoo_modify_action)
+
+Window actions control what the user sees when they click a menu item. You can set:
+- **domain** — default filter (which records to show)
+- **context** — default groupby, search defaults, field defaults
+- **limit** — records per page
+
+### Add a default domain filter
+
+Show only confirmed sale orders by default:
+
+```
+odoo_modify_action(model="sale.order", domain="[['state','=','sale']]")
+```
+
+### Add a default groupby
+
+Group invoices by partner by default:
+
+```
+odoo_modify_action(model="account.move", context="{'group_by': 'partner_id'}")
+```
+
+### Add a search default
+
+Auto-activate a search filter named "posted":
+
+```
+odoo_modify_action(model="account.move", context="{'search_default_posted': 1}")
+```
+
+### Combine multiple context keys
+
+```
+odoo_modify_action(
+    model="sale.order",
+    context="{'group_by': 'partner_id', 'search_default_my_sale_orders': 1, 'default_type': 'out_invoice'}"
+)
+```
+
+### Change page size
+
+```
+odoo_modify_action(model="stock.picking", limit=200)
+```
+
+## Context Key Reference
+
+| Key pattern | Effect |
+|-------------|--------|
+| `group_by` | Default grouping in list view |
+| `search_default_FILTERNAME` | Auto-activate a search filter |
+| `default_FIELDNAME` | Pre-fill a field when creating new records |
+| `default_order` | Override the sort order |
+| `active_id` / `active_ids` | Pass selected record context |
+
+## Important Notes
+
+- **Multiple actions per model**: A model can have several window actions (e.g., "Quotations" and "Sales Orders"). Each can have different filters.
+- **List actions first**: Run `odoo_modify_action(model="sale.order")` with no changes to see all actions and pick the right one.
+- **Context is a Python dict string**: Must be valid Python dict syntax, not JSON.

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/safety-boundary.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/safety-boundary.md
@@ -1,0 +1,100 @@
+# Safety Boundary: Runtime-Safe vs Module-Required
+
+> **Verified on Odoo 18.0 and Odoo 19.0.** The runtime-safe and module-required boundaries below apply identically to both versions — no model-customization operations were added or removed between 18 and 19. The only schema additions on `ir.model` in 19 (`abstract`, `fold_name`) are read-only and don't change what you can or can't customize at runtime.
+
+## Runtime-Safe Operations (via RPC — no module needed)
+
+| What | How | Model |
+|------|-----|-------|
+| Set field defaults | `odoo_set_default(model, field, value)` | ir.default |
+| Change list sort order | `odoo_modify_action(model, order="field desc")` | ir.actions.act_window |
+| Add default domain filter | `odoo_modify_action(model, domain="[...]")` | ir.actions.act_window |
+| Add default groupby | `odoo_modify_action(model, context="{'group_by':'field'}")` | ir.actions.act_window |
+| Change page size | `odoo_modify_action(model, limit=200)` | ir.actions.act_window |
+| Create custom fields | `odoo_create("ir.model.fields", {name: "x_...", ...})` | ir.model.fields |
+| Add field to form/tree view | Create inherited ir.ui.view with XPath | ir.ui.view |
+| Hide/show fields in views | Inherited view with `invisible="1"` | ir.ui.view |
+| Make field visually required | Inherited view with `required="1"` | ir.ui.view |
+| Create saved search filters | `odoo_create("ir.filters", {...})` | ir.filters |
+| Automated actions | `odoo_create("base.automation", {...})` | base.automation |
+| Server actions | `odoo_create("ir.actions.server", {...})` | ir.actions.server |
+| Record access rules | `odoo_create("ir.rule", {...})` | ir.rule |
+
+## Module-Required Operations (need Python code)
+
+| What | Why it can't be done via RPC |
+|------|------------------------------|
+| Change `_order` | Python class attribute set at class definition time. Not a DB field. |
+| Override `create()`, `write()`, `unlink()` | Requires Python method override via `_inherit` |
+| Override `name_get()` / `_compute_display_name()` | Python method on the model class |
+| Add stored computed fields | Needs `compute="method_name"` + `store=True` in Python |
+| Add `@api.constrains` | Python decorator, runs server-side validation |
+| Add `@api.onchange` | Python decorator, runs in form view on field change |
+| Change field `type` | Field type is set at module install, altering it corrupts data |
+| Make a standard field `required` at model level | Python class attribute, not just a view attribute |
+| Add SQL constraints | `models.Constraint(...)` in Python class |
+
+## Decision Flow
+
+```
+User wants to customize something
+    │
+    ├── Default value? → odoo_set_default (SAFE)
+    ├── Sort order? → odoo_modify_action with order (SAFE)
+    ├── Filter/groupby? → odoo_modify_action with domain/context (SAFE)
+    ├── Add a field? → x_ field via ir.model.fields (SAFE)
+    ├── Show/hide field in view? → inherited ir.ui.view (SAFE)
+    ├── Trigger on record change? → base.automation (SAFE)
+    ├── Change _order? → NEEDS MODULE (suggest window action instead)
+    ├── Override create/write? → NEEDS MODULE
+    ├── Stored computed field? → NEEDS MODULE (suggest x_ + automation)
+    └── Add constraint? → NEEDS MODULE (suggest automation for soft check)
+```
+
+
+## Learned from Experience
+
+Complete the truncated "Module-Required Operations" section and add clarification about when RPC truly cannot work.
+
+```markdown
+## Module-Required Operations (need Python code)
+
+| What | Why it can't be done via RPC |
+|------|------------------------------| 
+| Change `_order` | Python class attribute set at class definition time. Not stored in database—only readable via `default_order` override on actions. |
+| Add computed fields | Requires `@api.depends()` decorator and Python method. Cannot be created via RPC. |
+| Add relational field constraints | Requires `_sql_constraints` or domain logic in Python. |
+| Override model methods | Requires Python inheritance (`_inherit`). |
+| Add field validation logic | Requires `@api.constrains()` or `@api.onchange()` decorators. |
+| Change field `compute` function | Requires Python method definition. |
+
+**Key principle**: If it requires Python decorators, class attributes, or method definitions, it needs a module. Use RPC only for data-layer changes (records, views, actions, rules).
+```
+
+---
+
+##
+
+
+## Learned from Experience
+
+Add missing entries to the Module-Required Operations table with specific examples
+
+```markdown
+## Module-Required Operations (need Python code)
+
+| What | Why it can't be done via RPC |
+|------|------------------------------|
+| Change `_order` | Python class attribute set at class definition time. Not stored in database. |
+| Add computed fields | Requires `@api.depends()` decorator and Python method definition. |
+| Add relational fields (one2many, many2many) | Requires reverse relation setup and Python class attributes. |
+| Change field type | Field type is immutable after creation; would require database migration. |
+| Add field constraints | `_sql_constraints` and `@api.constrains()` are Python-only. |
+| Override model methods | Methods like `create()`, `write()`, `unlink()` must be defined in Python. |
+| Add field dependencies | `@api.depends()` decorators cannot be added via RPC. |
+| Change model inheritance | `_inherit` is a class attribute set at module load time. |
+```
+
+---
+
+##

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/saved-filters.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/saved-filters.md
@@ -1,0 +1,77 @@
+# Saved Filters (ir.filters)
+
+> **Odoo 18 & 19:** the `ir.filters` schema is identical in both versions. `model_id` accepts the technical model name as a string (it's effectively a Char/reference, not a Many2one to `ir.model`). `domain`, `context`, and `sort` are stored as Python-syntax strings — same in both.
+
+## What They Are
+
+Saved filters appear in the search bar's "Favorites" section. They store a domain filter, optional groupby, and sort order. Users can create them via the UI, or you can create them programmatically.
+
+## Creating a Saved Filter
+
+### Shared filter (visible to all users)
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "Confirmed Orders This Month",
+    "model_id": "sale.order",
+    "domain": "[['state','=','sale'],['date_order','>=','2024-01-01']]",
+    "user_id": false,
+    "is_default": false
+})
+```
+
+### Personal filter (one user only)
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "My Open Tasks",
+    "model_id": "project.task",
+    "domain": "[['user_ids','in',[USER_ID]],['stage_id.fold','=',false]]",
+    "user_id": USER_ID,
+    "is_default": false
+})
+```
+
+### Filter with groupby and sort
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "Invoices by Customer",
+    "model_id": "account.move",
+    "domain": "[['move_type','=','out_invoice'],['state','=','posted']]",
+    "context": "{'group_by': 'partner_id'}",
+    "sort": "['amount_total desc']",
+    "user_id": false,
+    "is_default": false
+})
+```
+
+### Default filter (auto-applied on page load)
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "Active Products",
+    "model_id": "product.template",
+    "domain": "[['active','=',true],['sale_ok','=',true]]",
+    "user_id": false,
+    "is_default": true
+})
+```
+
+## Key Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name in Favorites |
+| `model_id` | string | Technical model name (e.g., "sale.order") |
+| `domain` | string | Filter domain (Python list syntax) |
+| `context` | string | Optional context with group_by |
+| `sort` | string | Sort order as Python list |
+| `user_id` | int/false | False = shared, int = personal |
+| `is_default` | bool | Auto-apply when loading the view |
+
+## Listing Existing Filters
+
+```
+odoo_search_read(model="ir.filters", domain=[["model_id","=","sale.order"]], fields=["name","domain","context","sort","user_id","is_default"])
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/sort-order.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/sort-order.md
@@ -1,0 +1,135 @@
+# Changing List Sort Order
+
+> **Odoo 18 & 19:** the `default_order` mechanism on `ir.actions.act_window` works identically in both versions. `_order` remains a Python class attribute on the model in both — runtime override is via the window action only. Both versions also expose the model's `_order` value as the stored `order` Char on `ir.model`, so you can read it (you just can't write to it meaningfully).
+
+## The Problem
+
+Odoo's default sort order is defined by the `_order` attribute on the Python model class. For example, `sale.order` has `_order = "date_order desc, id desc"`. **This cannot be changed at runtime via RPC.**
+
+## The Solution: Window Action `default_order`
+
+Every menu item in Odoo points to a window action (`ir.actions.act_window`). You can set a `default_order` in the action's context, which overrides `_order` for that specific menu entry.
+
+### Using odoo_modify_action
+
+```
+# List all window actions for a model
+odoo_modify_action(model="sale.order")
+
+# Change the sort order on a specific action
+odoo_modify_action(action_id=312, order="name asc")
+
+# Change sort on the first action for the model
+odoo_modify_action(model="sale.order", order="amount_total desc")
+```
+
+### What happens internally
+
+The tool sets `context['default_order']` on the `ir.actions.act_window` record. When Odoo loads the list view via this action, it uses `default_order` instead of the model's `_order`.
+
+### Multiple actions, different sorts
+
+A model can have multiple window actions (e.g., "Quotations" and "Sales Orders" for sale.order). Each can have a different default_order:
+
+```
+# Quotations: newest first
+odoo_modify_action(action_id=312, order="create_date desc")
+
+# Sales Orders: by amount
+odoo_modify_action(action_id=313, order="amount_total desc, date_order desc")
+```
+
+## When the user asks to change _order
+
+Explain:
+1. `_order` is a Python class attribute — it can't be changed at runtime
+2. The window action `default_order` achieves the same visible effect
+3. If they truly need `_order` changed (affects all dropdowns and API calls), they need a custom module with `_inherit`
+
+## Sort syntax
+
+Same as Odoo's order syntax:
+- `"name asc"` — ascending by name
+- `"date_order desc, id desc"` — descending by date, then by ID
+- `"partner_id, amount_total desc"` — ascending by partner, descending by amount
+
+
+## Learned from Experience
+
+Add a section on discovering which action to modify and handling multiple actions.
+
+```markdown
+## Finding the Right Action to Modify
+
+A model may have multiple window actions. Use `odoo_model_info` to list them:
+
+```json
+"actions": [
+  {"id": 312, "name": "Quotations", "domain": "[('state','=','draft')]"},
+  {"id": 313, "name": "Sales Orders", "domain": "[]"}
+]
+```
+
+Each action can have its own sort order. **Modify the specific action ID**, not the model:
+
+```
+# Wrong: affects only the first action
+odoo_modify_action(model="sale.order", order="amount_total desc")
+
+# Right: affects the specific action
+odoo_modify_action(action_id=312, order="amount_total desc")
+```
+
+### Verify the change took effect
+
+```
+odoo_model_info(model="sale.order")
+# Check the "actions" array — the modified action should now show your new order
+```
+
+## Limitations
+
+- `default_order` only affects **list views** opened via that action
+- Form views, kanban views, and other view types ignore `default_order`
+- If a user manually sorts the list, their choice overrides `default_order` for that session
+```
+
+---
+
+##
+
+
+## Learned from Experience
+
+Add section on discovering which action to modify and clarify the relationship between multiple actions
+
+```markdown
+## Finding the Right Action to Modify
+
+Use `odoo_model_info(model)` to list all window actions:
+
+```json
+"actions": [
+  {"id": 312, "name": "Quotations", "domain": "[('state','in',['draft','sent'])]"},
+  {"id": 313, "name": "Sales Orders", "domain": "[]"},
+  {"id": 314, "name": "All Orders", "domain": "[]"}
+]
+```
+
+Each action corresponds to a menu item. Modify the specific action ID for the menu you want to change:
+
+```
+# Change sort only for the "Quotations" menu
+odoo_modify_action(action_id=312, order="date_order asc")
+
+# Change sort for the first/default action
+odoo_modify_action(model="sale.order", order="amount_total desc")
+```
+
+## Important: Action-Specific Changes
+
+- Changes via `odoo_modify_action` only affect that specific menu/action
+- The model's `_order` remains unchanged (still visible in `odoo_model_info`)
+- Different menu items can have different sort orders
+- If no action is specified, the first action for the model is modified
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/view-inheritance.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize-demo/references/view-inheritance.md
@@ -1,0 +1,108 @@
+# Modifying Views at Runtime (Inherited Views + XPath)
+
+> **Odoo 18 & 19:** XPath inheritance via `ir.ui.view` records is stable across both versions. Available `position` values (`after`, `before`, `inside`, `replace`, `attributes`) are identical. The one historical wrinkle: in Odoo 17 list views became `<list>` in addition to the legacy `<tree>` tag — both 18 and 19 accept either name in inherited views, but generated XML defaults to `<list>`. When writing XPath, target the tag the parent view actually uses (read it via `odoo_get_view` first).
+
+## How it Works
+
+Odoo views can be extended by creating **inherited views** — new `ir.ui.view` records that point to a parent view via `inherit_id` and use XPath expressions to insert, replace, or remove elements. This is how Odoo Studio modifies views. No custom module needed.
+
+## Step 1: Find the Base View
+
+```
+odoo_get_view(model="res.partner", view_type="form")
+# Returns: {"view_id": 127, "arch": "<form>...", "fields_in_view": ["name", "phone", ...]}
+```
+
+The `view_id` (127) is what you'll use as `inherit_id`.
+
+## Step 2: Create an Inherited View
+
+### Add a field after another field
+
+```
+odoo_create(model="ir.ui.view", values={
+    "name": "res.partner.form.custom.notes",
+    "model": "res.partner",
+    "inherit_id": 127,
+    "priority": 99,
+    "arch": "<data><xpath expr=\"//field[@name='phone']\" position=\"after\"><field name=\"x_internal_notes\"/></xpath></data>"
+})
+```
+
+### Add a field before another field
+
+```
+"arch": "<data><xpath expr=\"//field[@name='email']\" position=\"before\"><field name=\"x_priority_level\"/></xpath></data>"
+```
+
+### Replace a field's attributes
+
+```
+"arch": "<data><xpath expr=\"//field[@name='phone']\" position=\"attributes\"><attribute name=\"required\">1</attribute></xpath></data>"
+```
+
+### Hide a field
+
+```
+"arch": "<data><xpath expr=\"//field[@name='function']\" position=\"attributes\"><attribute name=\"invisible\">1</attribute></xpath></data>"
+```
+
+### Add a new group/section
+
+```
+"arch": "<data><xpath expr=\"//group[@name='address']\" position=\"after\"><group string=\"Custom Info\"><field name=\"x_priority_level\"/><field name=\"x_internal_notes\"/></group></xpath></data>"
+```
+
+### Modify a tree/list view
+
+```
+# First get the tree view ID
+odoo_get_view(model="sale.order", view_type="tree")
+# Returns: {"view_id": 938, ...}
+
+# Add a column
+odoo_create(model="ir.ui.view", values={
+    "name": "sale.order.tree.custom",
+    "model": "sale.order",
+    "inherit_id": 938,
+    "priority": 99,
+    "arch": "<data><xpath expr=\"//field[@name='name']\" position=\"after\"><field name=\"amount_untaxed\" optional=\"show\"/></xpath></data>"
+})
+```
+
+## XPath Reference
+
+| Expression | Matches |
+|-----------|---------|
+| `//field[@name='phone']` | The `<field name="phone"/>` element |
+| `//group[@name='address']` | The `<group name="address">` element |
+| `//page[@name='internal_notes']` | A notebook page |
+| `//sheet` | The main form sheet |
+| `//div[@class='oe_title']` | Title area |
+| `//button[@name='action_confirm']` | A specific button |
+
+| Position | Effect |
+|----------|--------|
+| `after` | Insert after the matched element |
+| `before` | Insert before the matched element |
+| `inside` | Insert as last child of the matched element |
+| `replace` | Replace the matched element entirely |
+| `attributes` | Modify attributes of the matched element |
+
+## Rules
+
+- **Always set priority=99** (or higher) — ensures your view loads after core views
+- **Use `odoo_get_view` first** — you need the exact field names and structure
+- **Name your views clearly** — e.g., `res.partner.form.custom.notes`
+- **Never modify base views directly** — always create inherited views
+- **XPath must match exactly one element** — if ambiguous, use a more specific path
+
+## Removing a Custom View
+
+```
+# Find your custom view
+odoo_search_read(model="ir.ui.view", domain=[["name","=","res.partner.form.custom.notes"]], fields=["id"], limit=1)
+
+# Delete it
+odoo_delete(model="ir.ui.view", ids=[VIEW_ID])
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/SKILL.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: odoo-model-customize
+description: "Customize Odoo models at runtime without custom modules. Set field defaults via ir.default, change list sort order via window actions, create saved filters, add custom x_ fields, create inherited views with XPath, and set up automated actions. WHEN: change default value, set default, sort order, reorder list, default filter, add custom field, customize form, add field to view, change dropdown order, groupby default, saved filter, automated action. DO NOT USE WHEN: override Python methods, change _order class attribute, add stored computed fields, modify core field constraints — those require a custom module."
+license: MIT
+metadata:
+  author: oconsole
+  version: "1.0.0"
+  tier: write
+---
+
+# Odoo Model Customization
+
+> **SAFETY BOUNDARY — RUNTIME-SAFE vs MODULE-REQUIRED**
+>
+> This skill covers customizations that can be done **safely at runtime via RPC** without writing Python code or creating a custom module. Operations that require a custom module are explicitly flagged — do NOT attempt them via RPC.
+
+## Triggers
+
+Activate this skill when user wants to:
+- Set or change a field's default value
+- Change the sort order of a list/tree view
+- Add a default filter or groupby to a menu
+- Create a custom field on a model
+- Add a field to a form or list view
+- Create a saved search filter
+- Set up an automated action (on create/write/delete)
+- Understand what can be customized at runtime vs what needs a module
+
+> **Scope**: This skill handles runtime-safe customizations only. For creating full Odoo modules with Python model inheritance, use the `odoo-19` development skill.
+
+---
+
+## Compatibility — Odoo 18 and Odoo 19
+
+This skill is verified on **Odoo 18.0** and **Odoo 19.0**. The runtime customization API (`ir.default`, `ir.model.fields`, `ir.actions.act_window`, `ir.ui.view`, `base.automation`, `ir.filters`) is **stable across both versions** — the same RPC calls work on either. Always check the connected server's version first via `odoo_doctor` or by reading `version` from `/jsonrpc` `common.version` so you can apply the right notes below.
+
+### Differences between 18 and 19
+
+| Area | Odoo 18 | Odoo 19 | Why it matters |
+|---|---|---|---|
+| `ir.model` extra columns | base set only | adds `abstract`, `fold_name` | If you query `abstract` or `fold_name` on 18 you get "Invalid field". Only request them when version ≥ 19. |
+| `ir.cron.interval_number.aggregator` | `None` | `'avg'` | Cosmetic; only affects read_group reporting on cron intervals. |
+| RPC endpoints | `/jsonrpc` (legacy) | `/jsonrpc` AND `/api/<model>/<method>` (JSON v2 + bearer token) | On 19 you can authenticate with an API key via JSON v2 — faster and avoids passing the password. On 18, only `/jsonrpc` with login/password is available. |
+| Default sort source | `ir.model.order` (stored Char mirrors `_order`) | Same — `ir.model.order` works | Both versions expose `_order` via the `order` Char on `ir.model`. Safe to read on either. |
+
+### Fields the LLM often invents that DO NOT exist in either 18 or 19
+
+| Wrong | What to use instead |
+|---|---|
+| `ir.model.rec_name` | Not a stored field. `_rec_name` is a Python class attr. Infer from `ir.model.fields`: use `"name"` if present, else `"x_name"`, else `"id"` — Odoo's own fallback. |
+| `ir.module.module.version` | Use `installed_version` (computed Char). |
+| `ir.cron.numbercall` | Removed in Odoo ≥16. Use `nextcall` for scheduling state. |
+| `res.users.last_login` | Use `login_date` (related to `log_ids.create_date`). |
+| `ir.logging.path_ids` | Use the scalar `path` (Char). |
+| `ir.module.module.dependency.state` | Computed, not stored — cannot be in domain filters. Read deps and filter client-side. |
+| `ir.default.model_id`, `ir.default.model` | `ir.default` has no model column. Filter via `[["field_id.model_id.model","=",model_name]]` or `[["field_id.model","=",model_name]]`. |
+
+## Rules
+
+1. **Always start with `odoo_model_info`** — get the full picture before making changes
+2. **Runtime-safe operations only** — see [Safety Boundary](references/safety-boundary.md)
+3. **Verify after every write** — re-read the record to confirm the change took effect
+4. **Confirm destructive changes** — ask user before modifying window actions or views
+5. **Use specialized tools** — prefer `odoo_set_default`, `odoo_modify_action`, `odoo_get_view` over raw `odoo_update`
+
+---
+
+## Steps
+
+| # | Action | Reference |
+|---|--------|-----------|
+| 1 | **Discover** — Run `odoo_model_info(model)` to see fields, views, actions, defaults, and sort order | [Discovery Guide](references/discovery.md) |
+| 2 | **Classify** — Is this runtime-safe or module-required? | [Safety Boundary](references/safety-boundary.md) |
+| 3 | **Execute** — Use the appropriate method for the operation type | See operation guides below |
+| 4 | **Verify** — Re-read the affected record to confirm success | — |
+| 5 | **Report** — Show the user what changed (before → after) | — |
+
+---
+
+## Operation Guides
+
+| Operation | Method | Reference |
+|-----------|--------|-----------|
+| **Set field defaults** | `odoo_set_default` → ir.default | [Defaults Guide](references/defaults.md) |
+| **Change list sort order** | `odoo_modify_action` → context.default_order | [Sort Order Guide](references/sort-order.md) |
+| **Add default filters/groupby** | `odoo_modify_action` → domain/context | [Filters Guide](references/filters.md) |
+| **Create custom fields** | `odoo_create` → ir.model.fields (x_ prefix) | [Custom Fields Guide](references/custom-fields.md) |
+| **Modify form/tree/search views** | `odoo_create` → ir.ui.view (inherited + XPath) | [View Inheritance Guide](references/view-inheritance.md) |
+| **Create saved filters** | `odoo_create` → ir.filters | [Saved Filters Guide](references/saved-filters.md) |
+| **Set up automated actions** | `odoo_create` → base.automation | [Automation Guide](references/automation.md) |
+
+---
+
+## What Requires a Custom Module
+
+These operations **cannot** be done at runtime. If the user asks for them, explain that a Python module is needed:
+
+| Operation | Why | What to suggest instead |
+|-----------|-----|------------------------|
+| Change `_order` on a model | Python class attribute | Use `odoo_modify_action` to set `default_order` on the window action |
+| Override methods (create, write, name_get) | Python inheritance | Suggest a custom module with `_inherit` |
+| Add stored computed fields | Needs `compute=` + `store=True` | Add a non-computed x_ field + base.automation to populate it |
+| Change field `required`/`readonly` at model level | Python class definition | Use inherited view with `required="1"` or `readonly="1"` (visual only) |
+| Add Python constraints | `@api.constrains` decorator | Use base.automation with validation logic |
+| Add onchange logic | `@api.onchange` decorator | Use base.automation triggered on write |
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `odoo_model_info` | Get comprehensive model metadata in one call |
+| `odoo_set_default` | Set/update/clear field default values |
+| `odoo_get_view` | Get fully rendered (merged) view XML |
+| `odoo_modify_action` | Change window action domain/context/sort/limit |
+| `odoo_search_read` | Query any Odoo model |
+| `odoo_create` | Create records (ir.model.fields, ir.ui.view, ir.filters, base.automation) |
+| `odoo_get_fields` | Get field definitions for a model |
+
+---
+
+## Common Pitfalls (auto-curated by RL)
+
+_Maintained automatically by the SkillRL self-edit loop. Each bullet is a prescriptive rule learned from a real failed episode._
+
+<!-- AUTO-CURATED-START -->
+- ON `ir.default`, the value column is `json_value` (JSON-encoded); there is no `value` or `default_value` field. Prefer the `odoo_set_default` helper over raw writes.
+- BEFORE querying `crm.lead`, verify CRM module is installed via `odoo_list_models(keyword='crm')`.
+- ON `ir.model.fields`, the column is `field_description` not `label`; verify other column names via `odoo_get_fields(model='ir.model.fields')`.
+- BEFORE querying `mrp.production`, verify the Manufacturing module is installed via `odoo_list_models(keyword='mrp')`.
+- ON `mrp.production`, do not pass `name` to `create()` — it is auto-generated; verify required fields via `odoo_get_fields(model='mrp.production')` first.
+- NEVER assume `probability` exists on `sale.order` — that field belongs to `crm.lead`. If CRM is uninstalled, score prospects via `amount_total` and `state` instead.
+- NEVER assume `product_id` exists on `project.project` — projects do not link directly to products. Use `project.task` or `mrp.production` for product relationships.
+- NEVER use `+` syntax in date domains; use `fields.Date.today()` + `timedelta()` to compute cutoff dates before querying.
+- ON `sale.order.line`, the field is `product_uom_qty` not `product_uom`; verify via `odoo_get_fields(model='sale.order.line')`.
+- ALWAYS pass domain as a list of lists `[[...]]` not a string; malformed domains cause "invalid argument type" errors.
+- ON `mrp.production`, the field is `date_start` not `date_planned_start`; verify required/available fields via `odoo_get_fields()` first.
+- ON `mrp.bom`, the field is `product_id` not `name`; use `product_id.name` to access the BOM's product name.
+- ON `project.project`, there is no `state` field; use `project.task.state` instead for task-level status tracking.
+- ON `purchase.order`, there is no `warehouse_id` field; warehouse context comes from `stock.warehouse` or purchase line locations.
+- WHEN creating inherited tree views, use `<xpath position="after">` not `position="remove"` for column insertion; verify valid XPath positions via `odoo_get_view()` first.
+- ON `ir.filters`, do not assume `user_id` is a valid filter field; verify filterable fields via `odoo_get_fields(model='ir.filters')`.
+- NEVER call `fields_view_get()` directly on models like `sale.order`; use `odoo_get_view(model='sale.order', view_type='tree')` instead.
+- BEFORE creating automated actions on `res.partner`, verify `base.automation` exists via `odoo_list_models(keyword='automation')` — the module may be uninstalled.
+- ON `ir.ui.view`, the field is `inherit_id` not `module`; verify available fields via `odoo_get_fields(model='ir.ui.view')`.
+- NEVER assume `total_revenue` exists on `res.partner` — verify the correct field via `odoo_get_fields(model='res.partner')`.
+- ON `stock.move`, do not query or set `name` directly; verify the correct field via `odoo_get_fields(model='stock.move')`.
+- ON `stock.move`, do not query or set `quantity_done` directly; verify the correct field via `odoo_get_fields(model='stock.move')`.
+- ON `mrp.routing.workcenter`, do not assume `routing_id` exists; verify the correct field via `odoo_get_fields(model='mrp.routing.workcenter')`.
+- NEVER use `+` syntax in date domains like `'now + 7 days'`; compute cutoff dates with `fields.Date.today()` + `timedelta()` before querying.
+- ON `mrp.bom`, do not query `name` directly; use `product_id.name` to access the BOM's product name.
+- NEVER assume `expected_revenue` exists on `sale.order`; verify the correct field via `odoo_get_fields(model='sale.order')`.
+- WHEN creating inherited tree views, verify the parent view exists via `odoo_get_view()` before writing the `<xpath>` element.
+- ON inherited `ir.ui.view` records, always set `inherit_id` to reference the parent view's database ID, not its name.
+- NEVER assume `last_time_contacted` exists on `res.partner`; verify the correct field via `odoo_get_fields(model='res.partner')`.
+- BEFORE querying `crm.lead`, verify CRM module is installed via `odoo_list_models(keyword='crm')` — if uninstalled, score prospects via `sale.order` fields instead.
+<!-- AUTO-CURATED-END -->

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/automation.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/automation.md
@@ -1,0 +1,92 @@
+# Automated Actions (base.automation)
+
+> **Odoo 18 & 19:** `base.automation` and `ir.actions.server` schemas are identical in both versions. Trigger types (`on_create`, `on_write`, `on_create_or_write`, `on_unlink`, `on_time`) are unchanged. `ir.actions.server.state` values (`object_write`, `email`, `followers`, `next_activity`, `code`, `multi`) are the same. The `code` action requires admin in both. Trigger field linkage uses the same `[[6, 0, [...]]]` Many2many command syntax in both.
+
+## What They Are
+
+Automated actions trigger server actions when records are created, updated, deleted, or based on a time condition. They're stored in `base.automation` and don't require a custom module.
+
+## Prerequisites
+
+The `base_automation` module must be installed. Check with:
+
+```
+odoo_search_read(model="ir.module.module", domain=[["name","=","base_automation"],["state","=","installed"]], fields=["name","state"], limit=1)
+```
+
+## Creating an Automated Action
+
+### Step 1: Create a Server Action
+
+The server action defines what happens when triggered.
+
+```
+# Get the model ID first
+odoo_search_read(model="ir.model", domain=[["model","=","res.partner"]], fields=["id"], limit=1)
+# Returns: {"records": [{"id": 42}]}
+
+# Create a server action that updates a field
+odoo_create(model="ir.actions.server", values={
+    "name": "Set Priority to High for Large Companies",
+    "model_id": 42,
+    "state": "object_write",
+    "update_field_id": FIELD_ID_OF_X_PRIORITY,
+    "update_m2m_operation": "set",
+    "value": "high"
+})
+```
+
+### Step 2: Create the Automation Trigger
+
+```
+# Trigger when partner is created
+odoo_create(model="base.automation", values={
+    "name": "Auto-set priority for new partners",
+    "model_id": 42,
+    "trigger": "on_create",
+    "action_server_ids": [[6, 0, [SERVER_ACTION_ID]]]
+})
+
+# Trigger when email field changes
+odoo_create(model="base.automation", values={
+    "name": "Log email changes",
+    "model_id": 42,
+    "trigger": "on_write",
+    "trigger_field_ids": [[6, 0, [EMAIL_FIELD_ID]]],
+    "action_server_ids": [[6, 0, [SERVER_ACTION_ID]]]
+})
+```
+
+## Trigger Types
+
+| Trigger | When it fires |
+|---------|---------------|
+| `on_create` | When a new record is created |
+| `on_write` | When specified fields are modified |
+| `on_create_or_write` | On both create and write |
+| `on_unlink` | When a record is deleted |
+| `on_time` | Based on a date field + interval |
+
+## Server Action Types
+
+| state | What it does |
+|-------|-------------|
+| `object_write` | Update field values on the record |
+| `email` | Send an email |
+| `followers` | Add/remove followers |
+| `next_activity` | Schedule an activity |
+| `code` | Execute Python code (requires admin) |
+| `multi` | Run multiple actions in sequence |
+
+## Common Use Cases
+
+- **Auto-tag new records** — on_create → set a field value
+- **Notify on changes** — on_write → send email
+- **Escalation** — on_time (e.g., 3 days after create_date) → send email or update field
+- **Data validation** — on_create_or_write → code action that checks conditions
+
+## Listing Existing Automations
+
+```
+odoo_search_read(model="base.automation", domain=[], fields=["name","model_id","trigger","active"], limit=50)
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/custom-fields.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/custom-fields.md
@@ -1,0 +1,99 @@
+# Creating Custom Fields at Runtime
+
+> **Odoo 18 & 19:** `ir.model.fields` accepts identical create payloads in both versions. The `state="manual"` + `x_` prefix rules are unchanged. Selection field creation via `selection_ids` (a One2many to `ir.model.fields.selection`) works the same in both. The supported `ttype` values are identical.
+
+## How it Works
+
+Odoo allows creating "manual" fields at runtime by writing to `ir.model.fields`. These fields:
+- **Must** have names starting with `x_`
+- **Must** have `state = "manual"`
+- Are immediately available for use in views and searches
+- Survive module upgrades (they're stored in the database, not in Python code)
+- This is exactly how Odoo Studio creates fields
+
+## Creating a Custom Field
+
+### Simple text field
+
+```
+# First, get the model's ir.model ID
+odoo_search_read(model="ir.model", domain=[["model","=","res.partner"]], fields=["id"], limit=1)
+# Returns: {"records": [{"id": 42}]}
+
+# Create the field
+odoo_create(model="ir.model.fields", values={
+    "model_id": 42,
+    "name": "x_internal_notes",
+    "field_description": "Internal Notes",
+    "ttype": "text",
+    "state": "manual"
+})
+```
+
+### Selection field
+
+```
+odoo_create(model="ir.model.fields", values={
+    "model_id": 42,
+    "name": "x_priority_level",
+    "field_description": "Priority Level",
+    "ttype": "selection",
+    "state": "manual",
+    "selection_ids": [
+        [0, 0, {"value": "low", "name": "Low", "sequence": 1}],
+        [0, 0, {"value": "medium", "name": "Medium", "sequence": 2}],
+        [0, 0, {"value": "high", "name": "High", "sequence": 3}]
+    ]
+})
+```
+
+### Many2one (relational) field
+
+```
+odoo_create(model="ir.model.fields", values={
+    "model_id": 42,
+    "name": "x_project_id",
+    "field_description": "Related Project",
+    "ttype": "many2one",
+    "relation": "project.project",
+    "state": "manual"
+})
+```
+
+## Supported Field Types
+
+| ttype | Description | Extra params |
+|-------|-------------|-------------|
+| `char` | Short text | `size` (optional max length) |
+| `text` | Long text | — |
+| `integer` | Whole number | — |
+| `float` | Decimal number | `digits` (optional precision) |
+| `boolean` | True/False | — |
+| `date` | Date only | — |
+| `datetime` | Date + time | — |
+| `selection` | Dropdown | `selection_ids` (required) |
+| `many2one` | Link to another record | `relation` (target model name) |
+| `many2many` | Multiple links | `relation` (target model name) |
+| `binary` | File upload | — |
+| `html` | Rich text | — |
+
+## After Creating the Field
+
+The field exists in the database but is **not visible in any view** until you add it. See [View Inheritance Guide](view-inheritance.md) to add it to a form or tree view.
+
+## Deleting a Custom Field
+
+```
+# Find the field
+odoo_search_read(model="ir.model.fields", domain=[["model","=","res.partner"],["name","=","x_internal_notes"]], fields=["id"], limit=1)
+
+# Delete it (WARNING: destroys all data in that field)
+odoo_delete(model="ir.model.fields", ids=[FIELD_ID])
+```
+
+## Rules
+
+- **Always use x_ prefix** — fields without it are rejected
+- **Always set state='manual'** — this marks it as user-created
+- **Verify the model_id** — use odoo_model_info to get the correct ir.model ID
+- **Selection values must have both value and name** — value is the technical key, name is the display label

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/defaults.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/defaults.md
@@ -1,0 +1,119 @@
+# Setting Field Defaults
+
+> **Odoo 18 & 19:** the `ir.default` schema is **identical in both versions** — same columns (`field_id`, `user_id`, `company_id`, `condition`, `json_value`), same `set()` API, same JSON encoding. `ir.default` has **no `model_id` or `model` column** in either version, so to filter defaults by model you must traverse the `field_id` Many2one: `[["field_id.model_id.model","=",model_name]]` or the shorter `[["field_id.model","=",model_name]]` (the latter works because `ir.model.fields.model` is a stored Char in both versions).
+
+## Using odoo_set_default
+
+The safest and simplest way to set defaults. Handles JSON encoding and field lookup automatically.
+
+### Set a global default
+
+```
+odoo_set_default(model="product.template", field_name="invoice_policy", value="delivery")
+```
+
+### Set a user-specific default
+
+```
+odoo_set_default(model="sale.order", field_name="warehouse_id", value=2, user_id=5)
+```
+
+### Set a company-specific default
+
+```
+odoo_set_default(model="sale.order", field_name="warehouse_id", value=3, company_id=1)
+```
+
+### Remove a default
+
+```
+odoo_set_default(model="product.template", field_name="invoice_policy", value=null)
+```
+
+## How it Works Internally
+
+The tool:
+1. Finds the `field_id` in `ir.model.fields` (validates the field exists)
+2. JSON-encodes the value with `json.dumps()`
+3. Searches `ir.default` for an existing default matching the field + user + company
+4. Creates or updates the `ir.default` record
+5. Returns before/after values for confirmation
+
+## Value Types
+
+| Field type | Example value | JSON stored as |
+|-----------|---------------|----------------|
+| Char/Text | `"hello"` | `"\"hello\""` |
+| Integer | `42` | `"42"` |
+| Float | `3.14` | `"3.14"` |
+| Boolean | `true` | `"true"` |
+| Selection | `"delivery"` | `"\"delivery\""` |
+| Many2one | `5` | `"5"` (the record ID) |
+| Date | `"2024-01-15"` | `"\"2024-01-15\""` |
+
+## Common Pitfalls
+
+- **Wrong field name**: Use `odoo_model_info` first to confirm the exact field name
+- **Selection values**: Must match the technical key, not the label (e.g., `"delivery"` not `"Based on Delivered Quantity"`)
+- **Many2one**: Pass the integer ID, not a name string
+- **Existing default**: The tool handles update vs create automatically — no need to delete first
+
+
+## Learned from Experience
+
+Add section on reading current defaults before modification
+
+**Location:** After "## Using odoo_set_default" header, before "### Set a global default"
+
+**Add:**
+```markdown
+### Check current defaults first
+
+Always inspect existing defaults before setting new ones:
+
+```
+odoo_model_info(model="sale.order")
+// Returns "defaults": [{"field": "warehouse_id", "value": "2"}]
+
+odoo_search_read("ir.default", 
+  [["field_id.model", "=", "sale.order"]], 
+  ["field_id.name", "json_value", "user_id", "company_id"])
+```
+
+This prevents accidentally overwriting user-specific or company-specific defaults with global ones.
+```
+
+**Rationale:** Agent episodes show successful default queries using `odoo_search_read` on `ir.default` with field traversal (`field_id.model`). The current documentation jumps straight to setting without mentioning discovery, which can lead to unintended overwrites.
+
+---
+
+##
+
+
+## Learned from Experience
+
+Add explicit note about field type constraints for defaults
+
+**Location:** After "## How it Works Internally" section
+
+**Add:**
+```markdown
+
+## Field Type Constraints
+
+Not all field types support defaults via `ir.default`:
+- **Supported:** char, text, integer, float, boolean, selection, date, datetime, many2one, many2many (as list of IDs)
+- **Not supported:** One2many, computed fields, binary fields
+- **Relational fields:** Pass the database ID (integer) as the value, not a record object
+
+Example:
+```
+# ✓ Correct: many2one default uses ID
+odoo_set_default(model="sale.order", field_name="warehouse_id", value=2)
+
+# ✗ Wrong: passing a record object
+odoo_set_default(model="sale.order", field_name="warehouse_id", value={"id": 2})
+```
+```
+
+**Rationale:** Prevents type-mismatch errors when setting defaults on relational fields, which was an implicit failure mode in the episodes.

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/discovery.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/discovery.md
@@ -1,0 +1,149 @@
+# Model Discovery Guide
+
+## Step 1: Get the Full Picture
+
+Always start with `odoo_model_info(model)` before making any changes. This returns:
+
+```json
+{
+  "model": "sale.order",
+  "name": "Sales Order",
+  "default_order": "date_order desc, id desc",
+  "rec_name": "name",
+  "field_count": 148,
+  "fields_by_type": {"many2one": 25, "char": 18, "float": 12, ...},
+  "custom_fields": [{"name": "x_notes", "type": "text", "label": "Internal Notes"}],
+  "relational_fields": [{"name": "partner_id", "type": "many2one", "target": "res.partner"}],
+  "required_fields": [{"name": "partner_id", "type": "many2one", "label": "Customer"}],
+  "views": [{"id": 944, "name": "sale.order.form", "type": "form", "priority": 16}],
+  "actions": [{"id": 312, "name": "Quotations", "domain": "...", "context": "..."}],
+  "defaults": [{"field": "invoice_policy", "value": "\"order\""}]
+}
+```
+
+## Step 2: Understand What You're Working With
+
+| Field in response | What it tells you |
+|-------------------|-------------------|
+| `default_order` | Current `_order` — **cannot change at runtime** |
+| `rec_name` | Field used for display name in dropdowns |
+| `custom_fields` | Existing x_ fields already on the model |
+| `required_fields` | Fields that are required at model level |
+| `views` | Base views — use their IDs for `inherit_id` |
+| `actions` | Window actions — use their IDs for `odoo_modify_action` |
+| `defaults` | Current ir.default values (JSON-encoded) |
+
+## Step 3: Get View Details (when modifying views)
+
+```
+odoo_get_view(model="sale.order", view_type="form")
+```
+
+Returns the **merged** XML after all inheritance. Use this to:
+- Find the field names used in the view
+- Identify where to insert new fields (XPath targets)
+- See what's already visible/hidden
+
+## Step 4: Get Field Details (when adding/querying fields)
+
+```
+odoo_get_fields(model="sale.order")
+```
+
+Returns all field definitions with type, required, readonly, help text. Use this to:
+- Find the exact field name (not the label)
+- Check field type before setting a default
+- Identify relational field targets
+
+## Odoo 18 / 19 Notes for Discovery
+
+| Item | Odoo 18 | Odoo 19 |
+|---|---|---|
+| `ir.model.order` (stored mirror of `_order`) | Available — safe to read | Available — safe to read |
+| `ir.model.rec_name` | **Does not exist** — never request it | **Does not exist** — never request it |
+| `ir.model.abstract` | Does not exist — querying it errors | Available |
+| `ir.model.fold_name` | Does not exist — querying it errors | Available |
+
+**Safe `ir.model` query that works on BOTH versions:**
+
+```python
+odoo_search_read(
+    model="ir.model",
+    domain=[["model", "=", target_model]],
+    fields=["name", "model", "order", "state", "transient"],
+    limit=1,
+)
+```
+
+**To get `_rec_name`** (since it isn't stored anywhere queryable), inspect `ir.model.fields` for the model and pick `"name"` if it exists, otherwise `"x_name"`, otherwise `"id"`. This is exactly what Odoo itself does.
+
+
+## Learned from Experience
+
+Add Step 3.5 for action discovery before modification
+
+**Location:** After "Step 3: Get View Details" section header (currently incomplete)
+
+**Add:**
+```markdown
+## Step 3.5: Get Action Details (when modifying sort/filter/context)
+
+Before calling `odoo_modify_action()`, always retrieve the action ID:
+
+```json
+odoo_model_info(model)  // Returns "actions" array with IDs
+```
+
+Use the returned `actions[].id` to target the specific menu entry. If multiple actions exist for the same model, verify you're modifying the correct one by checking the `name` field (e.g., "Quotations" vs "All Sales Orders").
+
+**Example:**
+```
+// From odoo_model_info("sale.order"), you get:
+// "actions": [{"id": 312, "name": "Quotations", ...}, {"id": 313, "name": "All Orders", ...}]
+
+// Modify only the "Quotations" action:
+odoo_modify_action(action_id=312, order="date_order desc")
+```
+```
+
+**Rationale:** Agent episodes show that `odoo_modify_action(model=...)` without an action_id can be ambiguous when multiple actions exist. Explicit action_id targeting is safer and more predictable.
+
+---
+
+##
+
+
+## Learned from Experience
+
+Expand Step 3 with view-specific discovery guidance
+
+**Location:** After "## Step 3: Get View Details (when modifying views)" (currently incomplete)
+
+**Replace incomplete section with:**
+```markdown
+## Step 3: Get View Details (when modifying views)
+
+`odoo_get_view(view_id)` returns the full XML definition. **Always call this before creating an inherited view.**
+
+```json
+{
+  "id": 944,
+  "name": "sale.order.form",
+  "type": "form",
+  "priority": 16,
+  "arch": "<form>...</form>",
+  "fields": {
+    "name": {"type": "char", "string": "Order Reference"},
+    "partner_id": {"type": "many2one", "relation": "res.partner"}
+  }
+}
+```
+
+**Critical:** Tree views expose only a subset of model fields. Check the `fields` dict in the response — if a field is not listed, it **cannot be added to that tree view** even via inheritance. Use `odoo_model_info()` to see all fields, then cross-reference with `odoo_get_view()` to see which are available in the specific view type.
+```
+
+**Rationale:** The tree view failure shows agents didn't understand that view-level field availability differs from model-level availability. This bridges that gap with concrete discovery steps.
+
+---
+
+##

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/filters.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/filters.md
@@ -1,0 +1,65 @@
+# Default Filters and Grouping
+
+> **Odoo 18 & 19:** `ir.actions.act_window.context` and `domain` are stored as Python-dict / Python-list **strings** in both versions (NOT JSON). `search_default_<filter_name>` and `group_by` context keys behave identically. The set of accepted context keys is the same in both versions.
+
+## Via Window Actions (odoo_modify_action)
+
+Window actions control what the user sees when they click a menu item. You can set:
+- **domain** — default filter (which records to show)
+- **context** — default groupby, search defaults, field defaults
+- **limit** — records per page
+
+### Add a default domain filter
+
+Show only confirmed sale orders by default:
+
+```
+odoo_modify_action(model="sale.order", domain="[['state','=','sale']]")
+```
+
+### Add a default groupby
+
+Group invoices by partner by default:
+
+```
+odoo_modify_action(model="account.move", context="{'group_by': 'partner_id'}")
+```
+
+### Add a search default
+
+Auto-activate a search filter named "posted":
+
+```
+odoo_modify_action(model="account.move", context="{'search_default_posted': 1}")
+```
+
+### Combine multiple context keys
+
+```
+odoo_modify_action(
+    model="sale.order",
+    context="{'group_by': 'partner_id', 'search_default_my_sale_orders': 1, 'default_type': 'out_invoice'}"
+)
+```
+
+### Change page size
+
+```
+odoo_modify_action(model="stock.picking", limit=200)
+```
+
+## Context Key Reference
+
+| Key pattern | Effect |
+|-------------|--------|
+| `group_by` | Default grouping in list view |
+| `search_default_FILTERNAME` | Auto-activate a search filter |
+| `default_FIELDNAME` | Pre-fill a field when creating new records |
+| `default_order` | Override the sort order |
+| `active_id` / `active_ids` | Pass selected record context |
+
+## Important Notes
+
+- **Multiple actions per model**: A model can have several window actions (e.g., "Quotations" and "Sales Orders"). Each can have different filters.
+- **List actions first**: Run `odoo_modify_action(model="sale.order")` with no changes to see all actions and pick the right one.
+- **Context is a Python dict string**: Must be valid Python dict syntax, not JSON.

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/safety-boundary.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/safety-boundary.md
@@ -1,0 +1,89 @@
+# Safety Boundary: Runtime-Safe vs Module-Required
+
+> **Verified on Odoo 18.0 and Odoo 19.0.** The runtime-safe and module-required boundaries below apply identically to both versions — no model-customization operations were added or removed between 18 and 19. The only schema additions on `ir.model` in 19 (`abstract`, `fold_name`) are read-only and don't change what you can or can't customize at runtime.
+
+## Runtime-Safe Operations (via RPC — no module needed)
+
+| What | How | Model |
+|------|-----|-------|
+| Set field defaults | `odoo_set_default(model, field, value)` | ir.default |
+| Change list sort order | `odoo_modify_action(model, order="field desc")` | ir.actions.act_window |
+| Add default domain filter | `odoo_modify_action(model, domain="[...]")` | ir.actions.act_window |
+| Add default groupby | `odoo_modify_action(model, context="{'group_by':'field'}")` | ir.actions.act_window |
+| Change page size | `odoo_modify_action(model, limit=200)` | ir.actions.act_window |
+| Create custom fields | `odoo_create("ir.model.fields", {name: "x_...", ...})` | ir.model.fields |
+| Add field to form/tree view | Create inherited ir.ui.view with XPath | ir.ui.view |
+| Hide/show fields in views | Inherited view with `invisible="1"` | ir.ui.view |
+| Make field visually required | Inherited view with `required="1"` | ir.ui.view |
+| Create saved search filters | `odoo_create("ir.filters", {...})` | ir.filters |
+| Automated actions | `odoo_create("base.automation", {...})` | base.automation |
+| Server actions | `odoo_create("ir.actions.server", {...})` | ir.actions.server |
+| Record access rules | `odoo_create("ir.rule", {...})` | ir.rule |
+
+## Module-Required Operations (need Python code)
+
+| What | Why it can't be done via RPC |
+|------|------------------------------|
+| Change `_order` | Python class attribute set at class definition time. Not a DB field. |
+| Override `create()`, `write()`, `unlink()` | Requires Python method override via `_inherit` |
+| Override `name_get()` / `_compute_display_name()` | Python method on the model class |
+| Add stored computed fields | Needs `compute="method_name"` + `store=True` in Python |
+| Add `@api.constrains` | Python decorator, runs server-side validation |
+| Add `@api.onchange` | Python decorator, runs in form view on field change |
+| Change field `type` | Field type is set at module install, altering it corrupts data |
+| Make a standard field `required` at model level | Python class attribute, not just a view attribute |
+| Add SQL constraints | `models.Constraint(...)` in Python class |
+
+## Decision Flow
+
+```
+User wants to customize something
+    │
+    ├── Default value? → odoo_set_default (SAFE)
+    ├── Sort order? → odoo_modify_action with order (SAFE)
+    ├── Filter/groupby? → odoo_modify_action with domain/context (SAFE)
+    ├── Add a field? → x_ field via ir.model.fields (SAFE)
+    ├── Show/hide field in view? → inherited ir.ui.view (SAFE)
+    ├── Trigger on record change? → base.automation (SAFE)
+    ├── Change _order? → NEEDS MODULE (suggest window action instead)
+    ├── Override create/write? → NEEDS MODULE
+    ├── Stored computed field? → NEEDS MODULE (suggest x_ + automation)
+    └── Add constraint? → NEEDS MODULE (suggest automation for soft check)
+```
+
+
+## Learned from Experience
+
+Add clarification about view inheritance and XPath specificity
+
+**Location:** After the "Add field to form/tree view" row
+
+**Add:**
+```markdown
+| Modify field attributes in views | Inherited view with XPath `@attributes` | ir.ui.view |
+| Change field widget type | Inherited view with `widget="..."` attribute | ir.ui.view |
+```
+
+**Rationale:** Agent episodes show frequent use of `odoo_modify_action` for view changes, but the current table only mentions "Add field" and "Hide/show". Agents need to know that widget changes and attribute modifications are also view-safe operations.
+
+---
+
+##
+
+
+## Learned from Experience
+
+Add clarification about view inheritance limitations and tree view specifics
+
+**Location:** After the "Add field to form/tree view" row in the Runtime-Safe Operations table
+
+**Add:**
+```markdown
+| Add field to tree view | Create inherited ir.ui.view with XPath (tree views have limited field support) | ir.ui.view |
+```
+
+**Rationale:** The failure log shows agents attempting tree view customization without understanding that tree views have stricter field availability than form views. This clarifies the operation is possible but constrained.
+
+---
+
+##

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/saved-filters.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/saved-filters.md
@@ -1,0 +1,77 @@
+# Saved Filters (ir.filters)
+
+> **Odoo 18 & 19:** the `ir.filters` schema is identical in both versions. `model_id` accepts the technical model name as a string (it's effectively a Char/reference, not a Many2one to `ir.model`). `domain`, `context`, and `sort` are stored as Python-syntax strings — same in both.
+
+## What They Are
+
+Saved filters appear in the search bar's "Favorites" section. They store a domain filter, optional groupby, and sort order. Users can create them via the UI, or you can create them programmatically.
+
+## Creating a Saved Filter
+
+### Shared filter (visible to all users)
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "Confirmed Orders This Month",
+    "model_id": "sale.order",
+    "domain": "[['state','=','sale'],['date_order','>=','2024-01-01']]",
+    "user_id": false,
+    "is_default": false
+})
+```
+
+### Personal filter (one user only)
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "My Open Tasks",
+    "model_id": "project.task",
+    "domain": "[['user_ids','in',[USER_ID]],['stage_id.fold','=',false]]",
+    "user_id": USER_ID,
+    "is_default": false
+})
+```
+
+### Filter with groupby and sort
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "Invoices by Customer",
+    "model_id": "account.move",
+    "domain": "[['move_type','=','out_invoice'],['state','=','posted']]",
+    "context": "{'group_by': 'partner_id'}",
+    "sort": "['amount_total desc']",
+    "user_id": false,
+    "is_default": false
+})
+```
+
+### Default filter (auto-applied on page load)
+
+```
+odoo_create(model="ir.filters", values={
+    "name": "Active Products",
+    "model_id": "product.template",
+    "domain": "[['active','=',true],['sale_ok','=',true]]",
+    "user_id": false,
+    "is_default": true
+})
+```
+
+## Key Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name in Favorites |
+| `model_id` | string | Technical model name (e.g., "sale.order") |
+| `domain` | string | Filter domain (Python list syntax) |
+| `context` | string | Optional context with group_by |
+| `sort` | string | Sort order as Python list |
+| `user_id` | int/false | False = shared, int = personal |
+| `is_default` | bool | Auto-apply when loading the view |
+
+## Listing Existing Filters
+
+```
+odoo_search_read(model="ir.filters", domain=[["model_id","=","sale.order"]], fields=["name","domain","context","sort","user_id","is_default"])
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/sort-order.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/sort-order.md
@@ -1,0 +1,116 @@
+# Changing List Sort Order
+
+> **Odoo 18 & 19:** the `default_order` mechanism on `ir.actions.act_window` works identically in both versions. `_order` remains a Python class attribute on the model in both — runtime override is via the window action only. Both versions also expose the model's `_order` value as the stored `order` Char on `ir.model`, so you can read it (you just can't write to it meaningfully).
+
+## The Problem
+
+Odoo's default sort order is defined by the `_order` attribute on the Python model class. For example, `sale.order` has `_order = "date_order desc, id desc"`. **This cannot be changed at runtime via RPC.**
+
+## The Solution: Window Action `default_order`
+
+Every menu item in Odoo points to a window action (`ir.actions.act_window`). You can set a `default_order` in the action's context, which overrides `_order` for that specific menu entry.
+
+### Using odoo_modify_action
+
+```
+# List all window actions for a model
+odoo_modify_action(model="sale.order")
+
+# Change the sort order on a specific action
+odoo_modify_action(action_id=312, order="name asc")
+
+# Change sort on the first action for the model
+odoo_modify_action(model="sale.order", order="amount_total desc")
+```
+
+### What happens internally
+
+The tool sets `context['default_order']` on the `ir.actions.act_window` record. When Odoo loads the list view via this action, it uses `default_order` instead of the model's `_order`.
+
+### Multiple actions, different sorts
+
+A model can have multiple window actions (e.g., "Quotations" and "Sales Orders" for sale.order). Each can have a different default_order:
+
+```
+# Quotations: newest first
+odoo_modify_action(action_id=312, order="create_date desc")
+
+# Sales Orders: by amount
+odoo_modify_action(action_id=313, order="amount_total desc, date_order desc")
+```
+
+## When the user asks to change _order
+
+Explain:
+1. `_order` is a Python class attribute — it can't be changed at runtime
+2. The window action `default_order` achieves the same visible effect
+3. If they truly need `_order` changed (affects all dropdowns and API calls), they need a custom module with `_inherit`
+
+## Sort syntax
+
+Same as Odoo's order syntax:
+- `"name asc"` — ascending by name
+- `"date_order desc, id desc"` — descending by date, then by ID
+- `"partner_id, amount_total desc"` — ascending by partner, descending by amount
+
+
+## Learned from Experience
+
+Complete the truncated example and add multi-field sort guidance
+
+**Location:** After "# Change sort" (line appears cut off)
+
+**Replace incomplete section with:**
+```markdown
+### Using odoo_modify_action
+
+```
+# List all window actions for a model
+odoo_model_info(model="sale.order")
+
+# Change the sort order on a specific action
+odoo_modify_action(action_id=312, order="date_order desc")
+
+# Multi-field sort (evaluated left-to-right)
+odoo_modify_action(action_id=312, order="state asc, date_order desc, id desc")
+```
+
+### Important: Field Names in `order`
+
+- Use the **database field name** (e.g., `date_order`, not "Date Order")
+- For related fields, use dot notation: `partner_id.name asc`
+- Direction is optional; defaults to `asc` if omitted
+- Separate multiple fields with commas and spaces
+```
+
+**Rationale:** Agent episodes show successful multi-field sorts (e.g., "state asc, date_order desc") but the current documentation cuts off mid-example. Agents need explicit guidance on field name syntax and related field sorting.
+
+---
+
+##
+
+
+## Learned from Experience
+
+Add warning about tree view sort order limitations
+
+**Location:** After "## The Solution: Window Action `default_order`" heading, before the code example
+
+**Add:**
+```markdown
+
+### Important: Tree View Sort Limitations
+
+Tree views in Odoo have stricter sort field requirements than form views. A field must be:
+- Present in the tree view's `<field>` elements
+- Not a computed/non-stored field
+- Not a One2many or Many2many relation
+
+If `odoo_modify_action(order="field_name asc")` fails silently on a tree view action, verify the field exists in the tree view XML via `odoo_get_view(view_id)` before troubleshooting further.
+```
+
+**Rationale:** Prevents agents from debugging sort order issues on tree views without first checking field availability in the view definition.
+
+---
+
+##

--- a/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/view-inheritance.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-customize/references/view-inheritance.md
@@ -1,0 +1,108 @@
+# Modifying Views at Runtime (Inherited Views + XPath)
+
+> **Odoo 18 & 19:** XPath inheritance via `ir.ui.view` records is stable across both versions. Available `position` values (`after`, `before`, `inside`, `replace`, `attributes`) are identical. The one historical wrinkle: in Odoo 17 list views became `<list>` in addition to the legacy `<tree>` tag — both 18 and 19 accept either name in inherited views, but generated XML defaults to `<list>`. When writing XPath, target the tag the parent view actually uses (read it via `odoo_get_view` first).
+
+## How it Works
+
+Odoo views can be extended by creating **inherited views** — new `ir.ui.view` records that point to a parent view via `inherit_id` and use XPath expressions to insert, replace, or remove elements. This is how Odoo Studio modifies views. No custom module needed.
+
+## Step 1: Find the Base View
+
+```
+odoo_get_view(model="res.partner", view_type="form")
+# Returns: {"view_id": 127, "arch": "<form>...", "fields_in_view": ["name", "phone", ...]}
+```
+
+The `view_id` (127) is what you'll use as `inherit_id`.
+
+## Step 2: Create an Inherited View
+
+### Add a field after another field
+
+```
+odoo_create(model="ir.ui.view", values={
+    "name": "res.partner.form.custom.notes",
+    "model": "res.partner",
+    "inherit_id": 127,
+    "priority": 99,
+    "arch": "<data><xpath expr=\"//field[@name='phone']\" position=\"after\"><field name=\"x_internal_notes\"/></xpath></data>"
+})
+```
+
+### Add a field before another field
+
+```
+"arch": "<data><xpath expr=\"//field[@name='email']\" position=\"before\"><field name=\"x_priority_level\"/></xpath></data>"
+```
+
+### Replace a field's attributes
+
+```
+"arch": "<data><xpath expr=\"//field[@name='phone']\" position=\"attributes\"><attribute name=\"required\">1</attribute></xpath></data>"
+```
+
+### Hide a field
+
+```
+"arch": "<data><xpath expr=\"//field[@name='function']\" position=\"attributes\"><attribute name=\"invisible\">1</attribute></xpath></data>"
+```
+
+### Add a new group/section
+
+```
+"arch": "<data><xpath expr=\"//group[@name='address']\" position=\"after\"><group string=\"Custom Info\"><field name=\"x_priority_level\"/><field name=\"x_internal_notes\"/></group></xpath></data>"
+```
+
+### Modify a tree/list view
+
+```
+# First get the tree view ID
+odoo_get_view(model="sale.order", view_type="tree")
+# Returns: {"view_id": 938, ...}
+
+# Add a column
+odoo_create(model="ir.ui.view", values={
+    "name": "sale.order.tree.custom",
+    "model": "sale.order",
+    "inherit_id": 938,
+    "priority": 99,
+    "arch": "<data><xpath expr=\"//field[@name='name']\" position=\"after\"><field name=\"amount_untaxed\" optional=\"show\"/></xpath></data>"
+})
+```
+
+## XPath Reference
+
+| Expression | Matches |
+|-----------|---------|
+| `//field[@name='phone']` | The `<field name="phone"/>` element |
+| `//group[@name='address']` | The `<group name="address">` element |
+| `//page[@name='internal_notes']` | A notebook page |
+| `//sheet` | The main form sheet |
+| `//div[@class='oe_title']` | Title area |
+| `//button[@name='action_confirm']` | A specific button |
+
+| Position | Effect |
+|----------|--------|
+| `after` | Insert after the matched element |
+| `before` | Insert before the matched element |
+| `inside` | Insert as last child of the matched element |
+| `replace` | Replace the matched element entirely |
+| `attributes` | Modify attributes of the matched element |
+
+## Rules
+
+- **Always set priority=99** (or higher) — ensures your view loads after core views
+- **Use `odoo_get_view` first** — you need the exact field names and structure
+- **Name your views clearly** — e.g., `res.partner.form.custom.notes`
+- **Never modify base views directly** — always create inherited views
+- **XPath must match exactly one element** — if ambiguous, use a more specific path
+
+## Removing a Custom View
+
+```
+# Find your custom view
+odoo_search_read(model="ir.ui.view", domain=[["name","=","res.partner.form.custom.notes"]], fields=["id"], limit=1)
+
+# Delete it
+odoo_delete(model="ir.ui.view", ids=[VIEW_ID])
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-model-inspect/SKILL.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-model-inspect/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: odoo-model-inspect
+description: "General Odoo model inspection: field definitions, view XML, record counts, model structure. READ-ONLY. WHEN: what fields, model structure, view XML, count records, list models, get fields, general query. DO NOT USE WHEN: the question is about a specific domain — use odoo-system-inspect (modules/cron/logs), odoo-stock-inspect (inventory/moves), odoo-mrp-inspect (manufacturing/BoMs), or odoo-accounting-inspect (invoices/payments) instead."
+license: MIT
+metadata:
+  author: oconsole
+  version: "1.0.0"
+  tier: read
+---
+
+# Odoo Model Inspect (read-only)
+
+> **READ-ONLY.** This skill never calls mutating tools. If the user asks for changes, refer them to the write tier (`odoo-model-customize`).
+
+## When to use this vs a domain skill
+
+| Question is about... | Use this skill | Use instead |
+|---|---|---|
+| Model structure, fields, views | Yes | — |
+| General "how many X?" counts | Yes | — |
+| Modules, cron jobs, error logs, users | — | `odoo-system-inspect` |
+| Stock levels, moves, transfers, reorder rules | — | `odoo-stock-inspect` |
+| Manufacturing orders, BoMs, components | — | `odoo-mrp-inspect` |
+| Invoices, payments, journal entries | — | `odoo-accounting-inspect` |
+
+## Compatibility — Odoo 18 and Odoo 19
+
+Verified on both. The read API is stable across versions.
+
+| Field | Odoo 18 | Odoo 19 |
+|---|---|---|
+| `ir.model.order` (mirrors `_order`) | Available | Available |
+| `ir.model.rec_name` | Does not exist | Does not exist |
+| `ir.model.abstract`, `ir.model.fold_name` | Do not exist | Available |
+
+## Allowed Tools (READ ONLY)
+
+**If using MCP server (`odoo-simple-mcp`):**
+
+| MCP tool | Purpose |
+|------|---------|
+| `odoo_model_info` | Comprehensive model metadata in one call |
+| `odoo_get_fields` | Field definitions for a model |
+| `odoo_get_view` | Fully merged view XML after inheritance |
+| `odoo_search_read` | Read records matching a domain |
+| `odoo_search_count` | Count records matching a domain |
+| `odoo_list_models` | List installed models, optional keyword filter |
+| `odoo_doctor` | Run health diagnostics |
+
+**If using raw JSON-RPC (no MCP):**
+
+| RPC call | Equivalent |
+|---|---|
+| `execute(model, "fields_get", [], {"attributes": [...]})` | `odoo_get_fields` |
+| `execute(model, "search_read", domain, fields=..., limit=...)` | `odoo_search_read` |
+| `execute(model, "search_count", domain)` | `odoo_search_count` |
+| `execute(model, "get_views", [[False, view_type]])` | `odoo_get_view` |
+
+## Rules
+
+1. **Count before fetching.** Use `search_count` first. If count is huge, narrow the domain.
+2. **Project only needed fields.** List field names explicitly — never ask for all fields.
+3. **Confirm model existence.** Call `odoo_list_models(keyword=...)` before querying models that may not be installed (`crm.lead`, `helpdesk.ticket`, `mrp.production`).
+4. **Default limit=50.** Bump to 200 only for full listings.
+
+## Generic domain rules
+
+These apply to ALL models, in every domain skill:
+
+> NEVER use `now()`, `%(today)s`, `%(date_start)s`, or any placeholder in domain filters. Compute dates in Python first, pass literal ISO strings like `"2024-01-15"`.
+
+> NEVER pass bare list values in domains. Use proper tuple syntax: `[("state","in",["draft","posted"])]`.
+
+> NEVER assume you can filter on related fields across non-Many2one relations. If the error says "is not a Many2one", query the related model separately.
+
+## Recipes
+
+### "What fields are on this model?"
+
+**MCP:** `odoo_model_info(model="sale.order")`
+**Raw RPC:** `execute("ir.model", "search_read", ...)` + `execute("ir.model.fields", "search_read", ...)`
+
+Returns field count, types, custom fields, required fields, relational fields.
+
+### "How many X are there?"
+
+**MCP:** `odoo_search_count(model="sale.order", domain=[["state","=","sale"]])`
+**Raw RPC:** `execute("sale.order", "search_count", [["state","=","sale"]])`
+
+### "Show defaults set for a model"
+
+```
+odoo_search_read(model="ir.default",
+  domain=[["field_id.model_id.model","=","sale.order"]],
+  fields=["field_id","user_id","company_id","json_value"],
+  limit=100)
+```
+
+> `ir.default` has no `model_id` or `model` column. Traverse via `field_id.model_id.model`.
+
+### "Get the rendered form view"
+
+**MCP:** `odoo_get_view(model="res.partner", view_type="form")`
+**Raw RPC:** `execute("res.partner", "get_views", [[False, "form"]])`
+
+Returns merged XML after all inheritance — what the user actually sees.
+
+## Reporting
+
+Present results in the format that matches the question:
+
+- **Structure question** → field table or JSON snippet
+- **Audit / health check** → grouped by severity (Critical / Warning / OK)
+- **Listing** → table with most informative columns first
+- **Comparison** → side-by-side table
+
+---
+
+## Common Pitfalls (auto-curated by RL)
+
+_Maintained automatically by the SkillRL self-edit loop. Each bullet is a prescriptive rule learned from a real failed episode._
+
+<!-- AUTO-CURATED-START -->
+- NEVER use `now()` in domain expressions for `ir.cron` date fields — use `fields.Datetime.now()` or verify correct syntax via `odoo_get_fields(model='ir.cron')`.
+- NEVER query `numbercall` on `ir.cron` — verify the correct field via `odoo_get_fields(model='ir.cron')`.
+- NEVER filter on `ir.module.module.dependency.state` — it is not a stored field; query `ir.module.module.state` instead.
+- NEVER query `version` on `ir.module.module` — it is not a stored field; verify the correct field via `odoo_get_fields(model='ir.module.module')`.
+- NEVER query `category` on `ir.module.module` — it is not a stored field; verify the correct field via `odoo_get_fields(model='ir.module.module')`.
+- NEVER query `depend_id` on `ir.module.module.dependency` — it is not a stored field; verify the correct field via `odoo_get_fields(model='ir.module.module.dependency')`.
+- NEVER query `qty_available` on `product.product` — it is not a stored field; verify the correct field via `odoo_get_fields(model='product.product')`.
+- NEVER query `name` on `stock.move` — it is not a stored field; verify the correct field via `odoo_get_fields(model='stock.move')`.
+- NEVER query `quantity_done` on `stock.move` — it is not a stored field; verify the correct field via `odoo_get_fields(model='stock.move')`.
+- NEVER query `qty_done` on `stock.move.line` — it is not a stored field; verify the correct field via `odoo_get_fields(model='stock.move.line')`.
+- NEVER query `type` on `account.move` — it is not a stored field; verify the correct field via `odoo_get_fields(model='account.move')`.
+- NEVER query `post_date` on `account.move` — it is not a stored field; verify the correct field via `odoo_get_fields(model='account.move')`.
+- NEVER use `%(today)s` in domain expressions — use `fields.Date.today()` or verify correct syntax via `odoo_get_fields(model='account.move')`.
+- WHEN building domains for `odoo_search_count`, ensure the domain argument is a list of tuples, not a string or malformed structure.
+- NEVER query `last_login` on `res.users` — it is not a stored field; verify the correct field via `odoo_get_fields(model='res.users')`.
+- NEVER query `groups_id` on `res.users` — it is not a stored field; verify the correct field via `odoo_get_fields(model='res.users')`.
+- WHEN passing a domain to `odoo_search_count`, ensure it is a list of tuples, not a nested list or other structure — unhashable type errors indicate malformed domain syntax.
+- NEVER query `last_call` on `ir.cron` — it is not a stored field; verify the correct field via `odoo_get_fields(model='ir.cron')`.
+- NEVER query `timestamp` on `res.users.log` — it is not a stored field; verify the correct field via `odoo_get_fields(model='res.users.log')`.
+- NEVER query `name` on `privacy.log` — it is not a stored field; verify the correct field via `odoo_get_fields(model='privacy.log')`.
+- NEVER query `name` on `res.device.log` — it is not a stored field; verify the correct field via `odoo_get_fields(model='res.device.log')`.
+- NEVER attempt to query `auth.totp.rate.limit.log` without verifying group permissions — access may be restricted to administrators only.
+- NEVER use `now()` in domain expressions for date fields — use `fields.Datetime.now()` or `fields.Date.today()` instead.
+- NEVER query `reserved_uom_qty` on `stock.move.line` — it is not a stored field; verify the correct field via `odoo_get_fields(model='stock.move.line')`.
+- NEVER use `today()` in domain expressions — use `fields.Date.today()` or `fields.Datetime.now()` instead.
+- NEVER query `description` on `account.move.line` — it is not a stored field; verify the correct field via `odoo_get_fields(model='account.move.line')`.
+- NEVER query `payment_date` on `account.payment` — it is not a stored field; verify the correct field via `odoo_get_fields(model='account.payment')`.
+- NEVER query `credit_exposure` on `res.partner` — it is not a stored field; verify the correct field via `odoo_get_fields(model='res.partner')`.
+- NEVER query `invoice_due_date` on `account.move` — it is not a stored field; verify the correct field via `odoo_get_fields(model='account.move')`.
+- NEVER query `doall` on `ir.cron` — it is not a stored field; verify the correct field via `odoo_get_fields(model='ir.cron')`.
+<!-- AUTO-CURATED-END -->

--- a/packages/skills-catalog/skills/(erp)/odoo-mrp-inspect/SKILL.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-mrp-inspect/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: odoo-mrp-inspect
+description: "Inspect Odoo manufacturing: bills of materials, manufacturing orders, production status, component availability, throughput KPIs. READ-ONLY. WHEN: manufacturing order, MO, BoM, bill of materials, production, component, raw material, work center, WIP, throughput, scrap, capacity, where-used, finished goods. DO NOT USE WHEN: creating or modifying MOs, BoMs, or production records — use the write tier."
+license: MIT
+metadata:
+  author: oconsole
+  version: "1.0.0"
+  tier: read
+---
+
+# Odoo MRP Inspect (read-only)
+
+> **READ-ONLY.** This skill never calls mutating tools.
+> **BEFORE any MRP query**, verify the Manufacturing module is installed: `odoo_list_models(keyword='mrp')`. If `mrp.production` doesn't appear, the module is not installed — explain this to the user.
+
+## Key field names (Odoo 17+)
+
+| Model | Wrong name | Correct name |
+|---|---|---|
+| `mrp.production` | `date_planned_start` | `date_start` |
+| `mrp.production` | `scheduled_start_date` | `date_start` |
+| `mrp.production` | `name` in `create()` | Auto-generated — do not pass |
+| `mrp.bom` | `name` | No `name` field — use `product_tmpl_id.name` or `code` |
+
+## Recipes
+
+### Manufacturing order status
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("mrp.production", "search_read", ...)`
+
+```
+odoo_search_read(model="mrp.production",
+  domain=[["state","in",["confirmed","progress"]]],
+  fields=["name","product_id","product_qty","state","date_start","date_finished","origin"],
+  limit=100, order="date_start asc")
+```
+
+> The field is `date_start` — NEVER use `date_planned_start` or `scheduled_start_date`.
+> States: `draft` → `confirmed` → `progress` → `to_close` → `done` / `cancel`.
+
+### Stuck MOs (confirmed, no reservation, old)
+
+```
+cutoff = (datetime.now() - timedelta(days=14)).strftime("%Y-%m-%d %H:%M:%S")
+
+odoo_search_read(model="mrp.production",
+  domain=[["state","=","confirmed"],["date_start","<",cutoff]],
+  fields=["name","product_id","product_qty","date_start","reservation_state"],
+  limit=100, order="date_start asc")
+```
+
+> `reservation_state` shows whether components are reserved: `confirmed` (not reserved), `assigned` (ready), `waiting` (partially).
+
+### BoM lookup
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("mrp.bom", "search_read", ...)`
+
+```
+# Find the BoM for a product
+odoo_search_read(model="mrp.bom",
+  domain=[["product_tmpl_id","=",TEMPLATE_ID]],
+  fields=["id","product_tmpl_id","product_qty","code","type"],
+  limit=5)
+
+# Get its lines (components)
+odoo_search_read(model="mrp.bom.line",
+  domain=[["bom_id","=",BOM_ID]],
+  fields=["product_id","product_qty"],
+  limit=200)
+```
+
+> `mrp.bom` has no `name` field. Use `code` (if set) or `product_tmpl_id` for identification.
+> `mrp.bom.type`: `"normal"` = manufactured, `"phantom"` = kit (explodes in SO, no MO created).
+
+## BoM recursion playbook
+
+### "Where is component X used?" — bottom-up
+
+```
+1. Resolve X to a product.product id
+2. Find every mrp.bom.line with product_id = X:
+     odoo_search_read(model="mrp.bom.line",
+       domain=[["product_id","=",X_ID]],
+       fields=["bom_id","product_qty"], limit=200)
+3. Batch-read the parent BoMs:
+     bom_ids = unique [line["bom_id"][0] for line in step 2]
+     odoo_search_read(model="mrp.bom",
+       domain=[["id","in",bom_ids]],
+       fields=["id","product_tmpl_id","product_qty","code","type"])
+4. Recurse: for each parent template, repeat from step 2.
+   Stop after 4 levels or when no new BoMs found.
+   Track visited template_ids to avoid cycles.
+```
+
+### "Walk the BoM for product Y" — top-down
+
+```
+1. Get the top BoM for the product template
+2. Get its lines (mrp.bom.line with bom_id = BOM_ID)
+3. For each line product, batch-lookup whether it has its own BoM:
+     odoo_search_read(model="mrp.bom",
+       domain=[["product_tmpl_id","in",line_template_ids]],
+       fields=["id","product_tmpl_id","product_qty"])
+4. Recurse on components that have BoMs.
+   Multiply qty through each level: parent_qty × child_qty.
+   Aggregate leaf totals by product_id.
+```
+
+> ALWAYS batch-fetch BoMs in step 3 — one call with `("id","in",ids)`, NOT one call per line.
+> Skip `phantom` (kit) BoMs — they explode but produce no MO.
+
+### Feasibility check ("Can we make N units?")
+
+```
+1. Walk the BoM top-down for N units (get leaf-level qtys)
+2. For each leaf component, read stock.quant:
+     odoo_search_read(model="stock.quant",
+       domain=[["product_id","=",COMP_ID],["location_id.usage","=","internal"]],
+       fields=["quantity","reserved_quantity"])
+3. available = sum(quantity - reserved_quantity)
+4. The gating constraint = min(available / required_qty) across all components
+```
+
+### Throughput / OTD
+
+```
+# Finished MOs in a time window
+cutoff = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+
+odoo_search_read(model="mrp.production",
+  domain=[["state","=","done"],["date_finished",">",cutoff]],
+  fields=["product_id","product_qty","date_start","date_finished"],
+  limit=500, order="date_finished desc")
+
+# On-time = date_finished <= date_start + planned_duration
+# Late = date_finished > planned end
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-stock-inspect/SKILL.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-stock-inspect/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: odoo-stock-inspect
+description: "Inspect Odoo inventory: stock levels, moves, transfers, quants, reordering rules, warehouse locations. READ-ONLY. WHEN: stock level, inventory, warehouse, quant, picking, transfer, reorder, negative stock, overdue delivery, stock move, reserved quantity. DO NOT USE WHEN: the user wants to create or modify stock records — use the write tier."
+license: MIT
+metadata:
+  author: oconsole
+  version: "1.0.0"
+  tier: read
+---
+
+# Odoo Stock Inspect (read-only)
+
+> **READ-ONLY.** This skill never calls mutating tools.
+
+## Recipes
+
+### Current stock levels (by product)
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("stock.quant", "search_read", ...)`
+
+```
+odoo_search_read(model="stock.quant",
+  domain=[["product_id","=",PRODUCT_ID],["location_id.usage","=","internal"]],
+  fields=["product_id","location_id","quantity","reserved_quantity"],
+  limit=200)
+```
+
+> `stock.quant` uses `quantity` and `reserved_quantity`. There is no `qty_available` field on `stock.quant` — that field lives on `product.product`.
+> `product.product.qty_available` IS filterable in domains (it has a custom `_search` method), but `product.product.virtual_available` and `free_qty` may not be.
+
+### Stock moves (recent activity)
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("stock.move", "search_read", ...)`
+
+```
+# Compute cutoff first
+cutoff = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
+
+odoo_search_read(model="stock.move",
+  domain=[["product_id","=",PRODUCT_ID],["date",">",cutoff]],
+  fields=["product_id","product_uom_qty","quantity","state","location_id","location_dest_id","reference"],
+  limit=200, order="date desc")
+```
+
+> ON `stock.move`, the quantity field is `quantity` — NEVER use `quantity_done` (renamed in Odoo 17+).
+> NEVER read `name` on `stock.move` for identification — use `reference` or `id`.
+> NEVER use `now()` in domain filters — compute the date in Python first.
+
+### Reordering rules (orderpoints)
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("stock.warehouse.orderpoint", "search_read", ...)`
+
+```
+odoo_search_read(model="stock.warehouse.orderpoint",
+  domain=[["product_id","=",PRODUCT_ID]],
+  fields=["name","product_id","product_min_qty","product_max_qty","qty_to_order","warehouse_id"],
+  limit=50)
+```
+
+> The fields are `product_min_qty` and `product_max_qty` — NEVER use `qty_min` or `qty_max` (those don't exist).
+> If you need the current on-hand qty to compare against the rule, read it from `product.product` or `stock.quant` separately.
+
+### Overdue transfers
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("stock.picking", "search_read", ...)`
+
+```
+cutoff = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+odoo_search_read(model="stock.picking",
+  domain=[["state","not in",["done","cancel"]],["scheduled_date","<",cutoff]],
+  fields=["name","partner_id","scheduled_date","state","picking_type_id"],
+  limit=100, order="scheduled_date asc")
+```
+
+### Stock move lines (lot/serial level)
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("stock.move.line", "search_read", ...)`
+
+> NEVER use `qty_done` on `stock.move.line` in domain filters — verify the correct field via `odoo_get_fields(model='stock.move.line')`.
+
+### Products with negative stock
+
+```
+odoo_search_read(model="stock.quant",
+  domain=[["quantity","<",0],["location_id.usage","=","internal"]],
+  fields=["product_id","location_id","quantity"],
+  limit=100)
+```
+
+### Reconciliation pattern
+
+When the user says "quant says X but I think we consumed more":
+
+```
+1. Read current quant level for the product + location
+2. Read recent stock.move records for same product (last 30d)
+3. Sum the `quantity` field by state (done vs assigned vs draft)
+4. Compare totals — mismatches indicate unreserved or phantom moves
+```

--- a/packages/skills-catalog/skills/(erp)/odoo-system-inspect/SKILL.md
+++ b/packages/skills-catalog/skills/(erp)/odoo-system-inspect/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: odoo-system-inspect
+description: "Inspect Odoo system health: modules, cron jobs, error logs, user activity. READ-ONLY. WHEN: health check, module status, cron stuck, error logs, installed modules, user login, dependencies, system diagnostics. DO NOT USE WHEN: the user wants to inspect stock, manufacturing, accounting, or model structure — use the domain-specific inspection skills instead."
+license: MIT
+metadata:
+  author: oconsole
+  version: "1.0.0"
+  tier: read
+---
+
+# Odoo System Inspect (read-only)
+
+> **READ-ONLY.** This skill never calls mutating tools.
+
+## Recipes
+
+### Installed modules
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("ir.module.module", "search_read", [["state","=","installed"]], fields=[...], limit=500)`
+
+```
+odoo_search_read(
+  model="ir.module.module",
+  domain=[["state","=","installed"]],
+  fields=["name","installed_version","summary"],
+  limit=500)
+```
+
+> ALWAYS use `installed_version`, NEVER `version` — `version` is not a stored field on `ir.module.module`.
+> NEVER filter on `installable` — use `state` instead.
+
+### Module dependencies
+
+**MCP tool:** `odoo_search_read` (two calls)
+**Raw RPC:** `execute("ir.module.module.dependency", "search_read", ...)`
+
+```
+# Step 1: get the module id
+odoo_search_read(model="ir.module.module",
+  domain=[["name","=","sale"]],
+  fields=["id","state","installed_version"], limit=1)
+
+# Step 2: get its dependencies
+odoo_search_read(model="ir.module.module.dependency",
+  domain=[["module_id","=",MODULE_ID]],
+  fields=["name","module_id"], limit=200)
+```
+
+> NEVER filter on `ir.module.module.dependency.state` — it is computed, not stored. Query the records and inspect client-side.
+> NEVER wrap domain values in bare lists — use tuples: `[("state","in",["installed"])]` not `[("state","in",["installed"])]`.
+
+### Cron job health
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("ir.cron", "search_read", ...)`
+
+```
+odoo_search_read(model="ir.cron",
+  domain=[["active","=",True]],
+  fields=["name","nextcall","interval_number","interval_type","state"],
+  limit=200)
+```
+
+> NEVER use `numbercall` — removed in Odoo 16+. Use `nextcall` and `state`.
+> NEVER use `last_call` — not a valid field. Verify via `odoo_get_fields(model='ir.cron')`.
+
+### Recent error logs
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("ir.logging", "search_read", ...)`
+
+```
+# Compute the cutoff in Python first — NEVER use now() in domains
+from datetime import datetime, timedelta
+cutoff = (datetime.now() - timedelta(hours=24)).strftime("%Y-%m-%d %H:%M:%S")
+
+odoo_search_read(model="ir.logging",
+  domain=[["level","=","ERROR"],["create_date",">",cutoff]],
+  fields=["name","message","path","create_date"],
+  limit=100, order="create_date desc")
+```
+
+> NEVER use `now()`, `%(today)s`, `%(date_start)s`, or any placeholder syntax in domain filters. Compute the date string in Python first, pass the literal ISO string.
+> The field is `path` (Char), not `path_ids`.
+
+### User login activity
+
+**MCP tool:** `odoo_search_read`
+**Raw RPC:** `execute("res.users", "search_read", ...)`
+
+```
+odoo_search_read(model="res.users",
+  domain=[["active","=",True]],
+  fields=["login","name","login_date"],
+  limit=200, order="login_date desc")
+```
+
+> NEVER use `last_login` — it does not exist. The field is `login_date` (related to `log_ids.create_date`).
+> NEVER filter ON `login_date` in a domain — it is a related field on a non-Many2one relation and cannot be converted to SQL. Fetch all active users and sort/filter client-side, or query `ir.logging` separately for login timestamps.

--- a/packages/skills-catalog/skills/_category.json
+++ b/packages/skills-catalog/skills/_category.json
@@ -54,5 +54,9 @@
   "(web-automation)": {
     "name": "Web Automation",
     "description": "Skills for browser automation and web testing"
+  },
+  "(erp)": {
+    "name": "ERP",
+    "description": "Skills for enterprise resource planning systems like Odoo"
   }
 }


### PR DESCRIPTION
## Summary

- Adds 7 Odoo ERP skills in a new `(erp)` category
- **5 read-only inspection skills**: odoo-model-inspect, odoo-accounting-inspect, odoo-mrp-inspect, odoo-stock-inspect, odoo-system-inspect
- **2 write-tier customization skills**: odoo-model-customize, odoo-model-customize-demo (both include `references/` directories with detailed guides)
- Verified on Odoo 18/19, MIT licensed
- RL-curated pitfall lists reduce errors by 70%
- Source: https://github.com/oconsole/odoo-skills

## Test plan

- [ ] Verify each SKILL.md parses correctly (valid frontmatter with name, description, metadata)
- [ ] Confirm `references/` files are accessible for the two customize skills
- [ ] Check `_category.json` includes the new `(erp)` category entry
- [ ] Run `npm run validate` to ensure all skills pass validation