### PR TITLE
fix: validate agent flag values in install and remove commands

### DIFF
--- a/packages/cli/src/cli/install.ts
+++ b/packages/cli/src/cli/install.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import { ensureSkillDownloaded, forceDownloadSkill, getRemoteSkills, installSkills } from '@tech-leads-club/core'
+import { AGENT_TYPES, ensureSkillDownloaded, forceDownloadSkill, getRemoteSkills, installSkills } from '@tech-leads-club/core'
 import type { AgentType, InstallOptions, SkillInfo } from '@tech-leads-club/core'
 
 import { ports } from '../ports'
@@ -72,7 +72,14 @@ export async function runCliInstall(options: InstallCliOptions): Promise<void> {
     process.exit(1)
   }
 
-  const agents = (options.agent || ['cursor', 'claude-code', 'windsurf']) as AgentType[]
+  const rawAgents = options.agent || ['cursor', 'claude-code', 'windsurf']
+  const invalidAgents = rawAgents.filter((a) => !AGENT_TYPES.includes(a as AgentType))
+  if (invalidAgents.length > 0) {
+    console.error(chalk.red(`❌ Unknown agent(s): ${invalidAgents.join(', ')}`))
+    console.error(chalk.dim(`   Valid agents: ${AGENT_TYPES.join(', ')}`))
+    process.exit(1)
+  }
+  const agents = rawAgents as AgentType[]
   const method = options.symlink ? 'symlink' : 'copy'
 
   console.log(chalk.blue(`⏳ Installing ${skills.length} skill(s) to ${agents.length} agent(s)...`))

--- a/packages/cli/src/cli/remove.ts
+++ b/packages/cli/src/cli/remove.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import { removeSkill } from '@tech-leads-club/core'
+import { AGENT_TYPES, removeSkill } from '@tech-leads-club/core'
 import type { AgentType } from '@tech-leads-club/core'
 
 import { ports } from '../ports'
@@ -21,7 +21,14 @@ export async function runCliRemove(options: RemoveCliOptions): Promise<void> {
   }
 
   const skillNames = Array.isArray(options.skill) ? options.skill : [options.skill]
-  const agents = (options.agent || ['cursor', 'claude-code', 'windsurf']) as AgentType[]
+  const rawAgents = options.agent || ['cursor', 'claude-code', 'windsurf']
+  const invalidAgents = rawAgents.filter((a) => !AGENT_TYPES.includes(a as AgentType))
+  if (invalidAgents.length > 0) {
+    console.error(chalk.red(`❌ Unknown agent(s): ${invalidAgents.join(', ')}`))
+    console.error(chalk.dim(`   Valid agents: ${AGENT_TYPES.join(', ')}`))
+    process.exit(1)
+  }
+  const agents = rawAgents as AgentType[]
 
   if (options.force) {
     console.log(chalk.yellow('⚠️  Force mode enabled - bypassing lockfile check'))


### PR DESCRIPTION
# Summary

- The --agent flag on both install and remove commands accepted any string, silently casting invalid values to AgentType and leading to confusing downstream failures
- Added upfront validation against the AGENT_TYPES constant; unknown agents now fail fast with a clear error message listing valid options
- No behavior change for valid inputs

# Test plan

- Run agent-skills install <skill> --agent unknown-agent and confirm it exits with ❌ Unknown agent(s): unknown-agent and lists valid agents
- Run agent-skills remove <skill> --agent unknown-agent and confirm the same error behavior
- Run install/remove with valid agents (e.g. --agent cursor) and confirm no regression