### PR TITLE
fix: Skills incorrect Last Modified

### DIFF
--- a/packages/marketplace/scripts/generate-data.ts
+++ b/packages/marketplace/scripts/generate-data.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'child_process'
 import * as fs from 'fs'
 import matter from 'gray-matter'
 import * as path from 'path'
@@ -42,6 +43,19 @@ function loadRegistry(): SkillsRegistry {
   return JSON.parse(fs.readFileSync(REGISTRY_FILE, 'utf-8'))
 }
 
+function getGitLastModified(filePath: string): string {
+  try {
+    const date = execFileSync('git', ['log', '-1', '--format=%aI', '--', filePath], {
+      cwd: WORKSPACE_ROOT,
+      encoding: 'utf-8',
+    }).trim()
+    if (date) return date.split('T')[0]
+  } catch {
+    // git not available or file not tracked
+  }
+  return new Date().toISOString().split('T')[0]
+}
+
 function readSkillContent(registrySkill: RegistrySkill): { content: string; lastModified: string } {
   const skillFile = path.join(SKILLS_DIR, registrySkill.path, 'SKILL.md')
 
@@ -51,19 +65,16 @@ function readSkillContent(registrySkill: RegistrySkill): { content: string; last
   }
 
   const fileContent = fs.readFileSync(skillFile, 'utf-8')
-  const stats = fs.statSync(skillFile)
-  const lastModified = stats.mtime.toISOString().split('T')[0]
+  const lastModified = getGitLastModified(skillFile)
 
   try {
     const { content } = matter(fileContent)
     return { content: content.trim(), lastModified }
   } catch {
-    // If YAML frontmatter parsing fails, extract content manually
     console.warn(`Failed to parse frontmatter for ${registrySkill.name}, using fallback`)
     const lines = fileContent.split('\n')
     let contentStart = 0
 
-    // Skip frontmatter if it exists (between --- markers)
     if (lines[0] === '---') {
       const endIndex = lines.findIndex((line, idx) => idx > 0 && line === '---')
       contentStart = endIndex > 0 ? endIndex + 1 : 1
@@ -97,7 +108,7 @@ function generateMarketplaceData(): MarketplaceData {
       .filter((f) => f.startsWith('references/') && f.endsWith('.md'))
       .map((f) => path.basename(f))
 
-    // Read content and lastModified from filesystem
+    // Read content and lastModified from git history
     const { content, lastModified } = readSkillContent(registrySkill)
 
     return {

--- a/packages/marketplace/src/data/skills.json
+++ b/packages/marketplace/src/data/skills.json
@@ -13,7 +13,7 @@
         "referenceFiles": [
           "WCAG.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -30,7 +30,7 @@
           "benchmarks-deliverability-tactics.md",
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -47,7 +47,7 @@
           "implementation-guide.md",
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -64,7 +64,7 @@
           "implementation-guide.md",
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -78,7 +78,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -92,7 +92,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -110,7 +110,7 @@
           "decision-trees.md",
           "mcp-guide.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -124,7 +124,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -138,7 +138,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -460,7 +460,7 @@
           "gotchas.md",
           "patterns.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -477,7 +477,7 @@
           "coding-principles.md",
           "notebook-spec.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -491,7 +491,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -505,7 +505,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -519,7 +519,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -533,7 +533,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -547,7 +547,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-11"
       }
     },
     {
@@ -564,7 +564,7 @@
           "podcast-community-cadence.md",
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -580,7 +580,7 @@
         "referenceFiles": [
           "LCP.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -594,7 +594,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -608,7 +608,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-11"
       }
     },
     {
@@ -624,7 +624,7 @@
         "referenceFiles": [
           "section-templates.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-11"
       }
     },
     {
@@ -638,7 +638,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -652,7 +652,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -668,7 +668,7 @@
         "referenceFiles": [
           "style-guide.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -682,7 +682,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -696,7 +696,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -714,7 +714,7 @@
           "excalidraw-schema.md",
           "icon-libraries.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-04"
       }
     },
     {
@@ -728,7 +728,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -745,7 +745,7 @@
           "figma-mcp-config.md",
           "figma-tools-and-prompts.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -759,7 +759,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -777,7 +777,7 @@
           "design-principles.md",
           "stitch-integration.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-23"
       }
     },
     {
@@ -799,7 +799,7 @@
           "typography.md",
           "ux-writing.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -813,7 +813,7 @@
         "hasScripts": true,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -827,7 +827,7 @@
         "hasScripts": true,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -844,7 +844,7 @@
           "implementation-guide.md",
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -858,7 +858,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -872,7 +872,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -888,7 +888,7 @@
         "referenceFiles": [
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -904,7 +904,7 @@
         "referenceFiles": [
           "PRINCIPLES.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -925,7 +925,7 @@
           "strangler-fig-patterns.md",
           "testing-safety-nets.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -946,7 +946,7 @@
           "themes.md",
           "troubleshooting.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-27"
       }
     },
     {
@@ -973,7 +973,7 @@
           "pattern-05-domain-grouping-quick-reference.md",
           "pattern-05-domain-grouping.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-04-16"
       }
     },
     {
@@ -989,7 +989,7 @@
         "referenceFiles": [
           "principles.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-04-16"
       }
     },
     {
@@ -1006,7 +1006,7 @@
           "directories-timing-mistakes.md",
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1027,7 +1027,7 @@
           "state-isolation.md",
           "testing-patterns.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-23"
       }
     },
     {
@@ -1045,7 +1045,7 @@
           "deployment-patterns.md",
           "netlify-toml.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1059,7 +1059,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1073,7 +1073,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1087,7 +1087,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1101,7 +1101,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1117,7 +1117,7 @@
         "referenceFiles": [
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1134,7 +1134,7 @@
           "implementation-guide.md",
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1148,7 +1148,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1162,7 +1162,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1180,7 +1180,7 @@
           "core-web-vitals.md",
           "image-optimization.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1194,7 +1194,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1210,7 +1210,7 @@
         "referenceFiles": [
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1224,7 +1224,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1238,7 +1238,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1258,7 +1258,7 @@
           "project-structure.md",
           "storage-patterns.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-23"
       }
     },
     {
@@ -1283,7 +1283,7 @@
           "service-types.md",
           "troubleshooting-basics.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1299,7 +1299,7 @@
         "referenceFiles": [
           "quick-reference.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1324,7 +1324,7 @@
           "python-fastapi-web-server-security.md",
           "python-flask-web-server-security.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1340,7 +1340,7 @@
         "referenceFiles": [
           "neo4j-import.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1357,7 +1357,7 @@
           "prompt-template.md",
           "security-controls-and-assets.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1371,7 +1371,7 @@
         "hasScripts": true,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1385,7 +1385,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1411,7 +1411,7 @@
           "performance.md",
           "theme-development.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1429,7 +1429,7 @@
           "patterns.md",
           "quality-checklist.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-27"
       }
     },
     {
@@ -1443,7 +1443,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1457,7 +1457,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1471,7 +1471,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1485,7 +1485,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1507,7 +1507,7 @@
           "red-team-adversarial.md",
           "socratic-questioning.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1538,7 +1538,7 @@
           "tasks.md",
           "validate.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-31"
       }
     },
     {
@@ -1552,7 +1552,7 @@
         "hasScripts": true,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1566,7 +1566,7 @@
         "hasScripts": false,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-03-13"
       }
     },
     {
@@ -1582,7 +1582,7 @@
         "referenceFiles": [
           "guideline.md"
         ],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     },
     {
@@ -1596,7 +1596,7 @@
         "hasScripts": true,
         "hasReferences": false,
         "referenceFiles": [],
-        "lastModified": "2026-04-20"
+        "lastModified": "2026-02-26"
       }
     }
   ],


### PR DESCRIPTION
## Fix: marketplace `lastModified` dates using git history instead of filesystem mtime

### Problem

The `lastModified` field in `skills.json` was derived from `fs.statSync().mtime`, which resets on `git clone`, `git checkout`, and CI runs. This caused dates to go backwards or change unpredictably whenever the data was regenerated.

### Solution

- Replaced `fs.statSync().mtime` with `git log -1 --format=%aI` to get the actual last commit date for each `SKILL.md`
- Used `execFileSync` (argv array) instead of `execSync` (shell string) to prevent command injection — important since skill paths originate from external PRs and this script runs in CI

### Changes

- `packages/marketplace/scripts/generate-data.ts` — added `getGitLastModified()` helper, removed `fs.statSync` usage

### Test plan

- [x] `npm run generate:data` succeeds
- [x] `skills.json` dates now reflect actual git commit history
- [x] Marketplace builds successfully with updated data
- [ ] Verify in CI that git history is available (standard `actions/checkout` includes it)
