### PR TITLE
feat: add tecture skill to (architecture)

### DIFF
--- a/packages/skills-catalog/skills/(architecture)/tecture/SKILL.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: tecture
+description: >
+  Author and maintain file-based architecture diagrams under `./architecture` (manifest.json + one
+  JSON file per diagram + one markdown description per node), grounded in the repo's actual tech
+  stack, deployables, and external dependencies. Use when the user says "document the architecture",
+  "draw the architecture", "create architecture diagrams", "update the architecture", or "split the
+  architecture into multiple diagrams". Do NOT use for editing an architecture through the Tecture
+  MCP server (use that directly), one-off inline mermaid diagrams in a single markdown file, or
+  non-structural documentation like deployment runbooks or API specs.
+metadata:
+  version: 1.0.0
+  author: github.com/tecture-io
+---
+
+# Tecture — file-based architecture diagrams
+
+Maintain a file-based C4 architecture at `./architecture/` (relative to the project root). The on-disk layout mirrors the Tecture data model but replaces UUIDs with slugs and moves long-form node descriptions into standalone markdown files.
+
+A good architecture is **grounded in the repo** (every node, edge, and technology corresponds to something concrete in the code), **right-sized per level** (L1 hides internals; L3 only appears when there is genuine internal complexity), and **comprehensible in 60 seconds** to a new engineer reading only the L1 diagram. The full quality bar is in the [Quality checklist](#quality-checklist) below — apply it before validation.
+
+## Directory layout
+
+```
+<project-root>/
+├── architecture/
+│   ├── manifest.json          # architecture metadata + diagram list
+│   ├── diagrams/
+│   │   └── <diagram-slug>.json  # one file per diagram
+│   └── descriptions/
+│       └── <node-id>.md       # one file per unique node id
+└── .tecture/                  # viewer-managed state (optional, auto-created)
+    └── layouts/<slug>.json    # per-diagram node positions/sizes
+```
+
+- Slugs are kebab-case (`[a-z0-9]+(-[a-z0-9]+)*`).
+- Node ids must be **globally unique across all diagrams** — the description filename is the node id.
+- Cross-diagram drill-down uses `subDiagramId = "<other-diagram-slug>"`, not a UUID.
+- `.tecture/` (at the project root, sibling to `architecture/`) is written by the Tecture viewer when users drag or resize nodes. Authoring agents must not hand-edit it. Deleting it is always safe — ELK auto-layout recomputes positions on the next load, and future user edits will recreate entries as needed. Commit or ignore it based on whether your team wants shared canonical layouts.
+
+## File formats
+
+### `manifest.json`
+
+```jsonc
+{
+  "name": "E-Commerce Platform",
+  "description": "Plain-text, 2-4 paragraphs separated by \\n\\n. No markdown.",
+  "topDiagram": "system-context",
+  "diagrams": ["system-context", "containers", "components-api"],
+}
+```
+
+### `diagrams/<slug>.json`
+
+```jsonc
+{
+  "name": "System Context",
+  "level": 1,
+  "meta": { "direction": "TB" },
+  "nodes": [
+    {
+      "id": "ecommerce",
+      "label": "E-Commerce Platform",
+      "subDiagramId": "containers",
+      "meta": { "type": "system" },
+    },
+  ],
+  "edges": [
+    {
+      "id": "e-customer-ecommerce",
+      "source": "customer",
+      "target": "ecommerce",
+      "label": "uses",
+      "meta": { "type": "calls" },
+    },
+  ],
+}
+```
+
+Nodes omit the `description` field entirely — prose lives in `descriptions/<node.id>.md`.
+
+### Nesting within a diagram
+
+A node can group 2–4 sibling nodes that share a runtime boundary by using `parentId` and setting `meta.isContainer: true` on the parent. The viewer renders the parent as a labeled container with its children laid out inside.
+
+```jsonc
+{
+  "nodes": [
+    { "id": "controllers", "label": "HTTP Controllers", "meta": { "type": "gateway", "isContainer": true } },
+    { "id": "auth-controller", "label": "Auth Controller", "parentId": "controllers", "meta": { "type": "service" } },
+    {
+      "id": "catalog-controller",
+      "label": "Catalog Controller",
+      "parentId": "controllers",
+      "meta": { "type": "service" },
+    },
+    { "id": "order-controller", "label": "Order Controller", "parentId": "controllers", "meta": { "type": "service" } },
+    { "id": "order-service", "label": "Order Service", "meta": { "type": "service" } },
+  ],
+}
+```
+
+Constraints: children must live in the **same diagram** as the parent; the parent must set `meta.isContainer: true`; nesting is **one level deep** (no grandchildren — the validator rejects a grandchild and points you to `subDiagramId` instead).
+
+**Grouping vs. drill-down.** Two mechanisms, one decision:
+
+- **2–4 things share an obvious runtime boundary and belong on the same level?** Use `parentId` (same diagram). Edges into/out of the group still work.
+- **3+ things warrant their own page, with edges only the reader at that level should see?** Use `subDiagramId` (separate diagram, next C4 level).
+- **Default**: flat. Don't nest if the grouping isn't load-bearing.
+
+### `descriptions/<node-id>.md`
+
+Free-form GitHub-flavored markdown. Convention: 1–2 sentence summary, then `## Responsibilities` and `## Tech Stack` sections.
+
+**Embed mermaid diagrams** with a standard fenced block (` ```mermaid `). The viewer renders the block inline as an SVG and lets users click an expand affordance to open a full-screen lightbox — useful for illustrating runtime behavior that the static C4 diagram cannot: request/response sequences, state machines, decision flows, retry/error branches. Any diagram type mermaid supports works (`sequenceDiagram`, `flowchart`, `stateDiagram-v2`, `erDiagram`, `classDiagram`, `gantt`, …).
+
+Use mermaid sparingly — one diagram per description, only when the prose is easier to grasp with a picture. If a description needs several diagrams, that's usually a hint to split the component into smaller nodes.
+
+Example description with a mermaid block:
+
+````markdown
+Node.js REST API backing the storefront and admin app.
+
+## Responsibilities
+
+- Authenticate sessions and authorise requests
+- Create orders and publish `order.created` to the event bus
+
+## Checkout Sequence
+
+```mermaid
+sequenceDiagram
+  Storefront->>API Service: POST /orders
+  API Service->>Postgres: INSERT order
+  API Service->>Event Bus: publish order.created
+  API Service-->>Storefront: 201 Created
+```
+````
+
+Full schema details (all fields, enums, constraints): see [references/schema.md](references/schema.md).
+Minimal working example: see [references/example/](references/example/).
+Machine-readable schemas (JSON Schema Draft 2020-12): [references/schemas/manifest.schema.json](references/schemas/manifest.schema.json), [references/schemas/diagram.schema.json](references/schemas/diagram.schema.json).
+
+## Workflow
+
+Three phases — **Discover → Map → Author**. Do not skip Phase A and dive straight into JSON; the most common failure mode is a generic, template-shaped architecture that names the right C4 levels but misses what makes _this_ repo distinctive.
+
+Stack-specific recipes, an external-system catalog, and a worked example live in [references/discovery.md](references/discovery.md). Read it once before authoring an architecture for an unfamiliar repo shape.
+
+### Phase A — Discover (read-only)
+
+Before writing any JSON, gather evidence for these seven artifacts. **Do not guess** — find the file or dependency that proves it.
+
+1. **Repo shape** — single app, monorepo (one or many deployables), microservices, library/SDK, CLI, mobile, data pipeline. Detect from workspace files (`pnpm-workspace.yaml`, `lerna.json`, `turbo.json`, `go.work`, Cargo workspaces), top-level directories (`packages/`, `services/`, `apps/`, `cmd/`), and the count of `Dockerfile`s.
+2. **Primary stack** — read every `package.json`, `pyproject.toml`, `requirements*.txt`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`, `Gemfile`, `composer.json`, `mix.exs`. Note the _frameworks_ (Next.js, FastAPI, Django, NestJS, Spring Boot, gin, axum), not just the language.
+3. **Deployables** — anything that runs as a long-lived process: `Dockerfile`s, `docker-compose.yml` services, `Procfile`, `serverless.yml`, k8s manifests, GitHub Actions deploy jobs, `bin/` entry points, `scripts.start`/`scripts.dev`.
+4. **Datastores & infra** — env vars matching `*_URL`/`*_DSN`/`*_HOST`/`*_BUCKET`; ORM configs (`prisma/schema.prisma`, Django `DATABASES`, `alembic.ini`); IaC under `terraform/`/`cdk/`/`pulumi/`.
+5. **External SDKs / SaaS** — provider SDK imports (`stripe`, `@sendgrid/*`, `@aws-sdk/*`, `boto3`, `openai`, `@anthropic-ai/sdk`, `@clerk/*`, `@sentry/*`); webhook routes; OAuth providers. Each match is usually an external node.
+6. **Actors / personas** — distinct frontends (admin vs end-user), auth roles, public API consumers, CLI users, cron/CI callers. Different behaviors → different person nodes.
+7. **Purpose** — top-level README + the `description` field in the package manifest + the primary entry point. This seeds `manifest.description` and the top-system description.
+
+### Phase B — Map discovery → C4
+
+Translate evidence using the patterns in [references/discovery.md](references/discovery.md). Universal rules:
+
+- **L1 (System Context)** — one node for the system + person actors + every external SaaS/datastore that lives outside _your_ deployable boundary. **3–5 nodes total. Never name internal services here.**
+- **L2 (Containers)** — one node per deployable from A3 + one node per managed datastore/broker from A4 + each external from A5. **4–8 nodes**, edges with concrete labels (`REST`, `gRPC`, `order.created`, `reads/writes`).
+- **L3 (Components)** — _optional_. Add only when an L2 container has 3+ separable internal parts that genuinely help a reader (e.g. an API split into auth/catalog/orders controllers + repos). **3–6 nodes**, never just a renamed re-arrangement of L2.
+
+Stack idioms differ — a Next.js + Postgres app, a Django monolith, a FastAPI + Celery service, a microservice mesh, a CLI, a data pipeline each get a different L2 shape. Use the matching recipe in [references/discovery.md](references/discovery.md) as a starting prior, then adjust to what is actually in the repo.
+
+### Phase C — Author & self-evaluate
+
+1. **Write child diagrams first** (L3 → L2 → L1) so slugs exist before parents reference them via `subDiagramId`.
+2. **For each diagram**, write `diagrams/<slug>.json`, then create `descriptions/<node-id>.md` for **every** node. Lead each description with one sentence of _responsibility_ — what this node owns, not a rephrasing of its label.
+3. **Write `manifest.json`** with `name`, `description` (2–4 plain-text paragraphs), `topDiagram` set to the L1 slug, and `diagrams` listing every slug.
+4. **Run the [Quality checklist](#quality-checklist)** against the draft. Fix anything that fails.
+5. **Validate** (see below). Fix every error before reporting success.
+
+## Quality checklist
+
+The validator checks _shape_. This checklist checks _meaning_ — apply it before running the validator. Aim for ≥10/12 on a fresh architecture; treat any miss as a real defect, not a stylistic preference.
+
+1. **60-second comprehension** — Read only the L1 diagram + the top-system description. Can a new engineer answer "what does this system do, who uses it, what does it depend on"?
+2. **Evidence-grounded** — For each node, name the file or dependency that proves it exists (a `Dockerfile`, a `package.json` entry, an env var, an SDK import). No node should be "I think there's probably one of these."
+3. **Right abstraction per level** — L1 hides internals; L2 shows deployables and managed infra; L3 appears only when an L2 container has 3+ meaningfully separable parts.
+4. **Boundaries match real seams** — Each node corresponds to a deployable, process, package, or module with its own contract. Could you imagine each node being deployed, replaced, or owned independently?
+5. **Edges express runtime relationships** — Every edge label is a verb or protocol (`REST`, `gRPC`, `order.created`, `reads/writes`, `webhook`). No `uses` / `depends on` / `interacts with`.
+6. **Technology authenticity** — Every `meta.technology` matches a real entry in a manifest, lockfile, or Dockerfile. Use [Simple Icons](https://simpleicons.org) slugs.
+7. **Drill-down adds information** — Each `subDiagramId` exposes structure not visible at the parent level. If removing the sub-diagram costs no understanding, delete it. Use `parentId` grouping when 2–4 nodes share a boundary on the same level; reach for `subDiagramId` only when the inner structure earns its own page.
+8. **Descriptions explain why, not what** — Strip the heading from any `descriptions/*.md`; you should still be able to tell which node it describes from the responsibilities. If not, the description is too generic.
+9. **Coverage of externals** — Grep for `*_URL`, `*_KEY`, and common SDK imports (`stripe`, `boto3`, `@aws-sdk/*`, `openai`, `@anthropic-ai/sdk`). Every match maps to a node.
+10. **Diagrams fit on one screen** — L1: 3–5 nodes; L2: 4–8; L3: 3–6. Anything bigger means split into a deeper level.
+11. **Stable, code-derived names** — Labels match what the code calls things (directory names, package names, service names). Don't invent synonyms.
+12. **Reusable on update** — When code changes (e.g. "we added a Redis cache"), a focused 1–2 file diff should be enough. If a small change forces a rewrite, the boundaries are wrong.
+
+Common anti-patterns to watch for: "Business Logic" / "Service Layer" nodes; L1 diagrams that name internal services; L3 diagrams that just rename L2; edges labeled `uses`; technologies you didn't grep for. See [references/discovery.md](references/discovery.md#anti-patterns-do-not-do-these) for the full list.
+
+## Updating an existing architecture
+
+- Adding a node: write the node object, write the description `.md`, add an edge if applicable, then re-validate.
+- Renaming a node id: rename the description file to match, update every `parentId`/`subDiagramId`/`source`/`target` reference, then re-validate.
+- Removing a diagram: remove the file, remove the slug from `manifest.diagrams`, clear any `subDiagramId` that pointed to it, and delete description `.md`s for nodes that no longer appear anywhere.
+
+Write the complete file each time — do not try to patch JSON by hand with partial objects.
+
+## Validation (always run before reporting done)
+
+Run the bundled validator from the project root. Replace `<SKILL_DIR>` with wherever this skill is installed — commonly `.claude/skills/tecture`, `.github/skills/tecture`, `.cursor/skills/tecture`, or `.agents/skills/tecture`:
+
+```
+node <SKILL_DIR>/scripts/validate.mjs
+```
+
+By default it checks `./architecture`. Pass a path to validate a different location: `node <SKILL_DIR>/scripts/validate.mjs path/to/other-arch`.
+
+The validator checks:
+
+- **Shape** — every file matches the JSON Schema (field presence, types, enum values, slug patterns, no unknown fields).
+- **Manifest consistency** — `topDiagram` is listed in `diagrams[]`; every listed slug has a matching `diagrams/<slug>.json`; files on disk that aren't listed produce a warning.
+- **Node references** — `parentId` points to a same-diagram node whose `meta.isContainer` is true, the `parentId` chain has no cycles, and nesting is at most one level deep (grandchildren are rejected — promote to a child diagram via `subDiagramId`). `subDiagramId` points to an existing diagram slug and is not self-referential.
+- **Edge references** — `source` and `target` resolve to nodes in the same diagram.
+- **Global node-id uniqueness** — node ids don't collide across diagrams (required because descriptions are keyed by node id).
+- **Descriptions** — every node id has a matching `descriptions/<id>.md`; orphan description files produce a warning.
+- **Cycles** — the `subDiagramId` drill-down graph is acyclic.
+
+Exit codes: `0` success, `1` validation failure, `2` internal error. Non-zero exit means there is still work to do — fix and re-run.

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/discovery.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/discovery.md
@@ -1,0 +1,233 @@
+# Discovery & mapping reference
+
+How to go from "here is a repo" to "here is an architecture" without producing a generic, template-shaped diagram. Read this **before** authoring the first JSON file.
+
+The goal is not to inventory every directory — it is to build the smallest set of nodes and edges that lets a new engineer answer three questions in 60 seconds:
+
+1. What does this system do, and who uses it?
+2. What does it depend on (datastores, brokers, external SaaS)?
+3. Where would I make a change of type X?
+
+Everything below serves that goal.
+
+## Phase A — Discover (read-only)
+
+Before writing any JSON, gather evidence for six artifacts. Treat this as a checklist; if you cannot fill in an artifact, _find it_ — do not guess.
+
+### A1. Repo shape
+
+Pick one. Determines L2 granularity.
+
+| Shape                               | Signals                                                                                                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Single app**                      | One `package.json` / `pyproject.toml`; one `Dockerfile` (or none); no workspace files                                                                |
+| **Monorepo (libraries + 1 app)**    | `pnpm-workspace.yaml` / `lerna.json` / `turbo.json` / `nx.json` / `go.work` / Cargo workspace, but only one `packages/*` or `apps/*` is a deployable |
+| **Monorepo (multiple deployables)** | Workspace files **and** multiple deployables (multiple `Dockerfile`s, multiple `apps/*`, multiple `cmd/*`)                                           |
+| **Microservices**                   | `services/*` or `cmd/*` directories, each with its own `Dockerfile`/manifest, often a shared infra/proto directory                                   |
+| **Library / SDK**                   | A single `package.json` whose `main`/`exports` ships code for _consumption_; no `bin`/server entry point; tests but no Dockerfile                    |
+| **CLI tool**                        | `bin` field in `package.json`, or `cmd/main.go`, or `[project.scripts]` in `pyproject.toml`; no long-running server                                  |
+| **Mobile app**                      | `ios/`, `android/`, `App.tsx` + React Native deps, or Flutter `pubspec.yaml`                                                                         |
+| **Data pipeline**                   | Airflow `dags/`, dbt `models/`, Spark/Beam jobs, scheduled GitHub Actions, no HTTP server                                                            |
+
+### A2. Primary stack
+
+Read every package manifest at the repo root and one level down. Note frameworks, not just languages:
+
+- Node: `package.json` → `dependencies`. Note React/Next/Vue/Svelte (frontend), Express/Fastify/NestJS/Hono (server), Prisma/Drizzle/TypeORM (ORM), bullmq/inngest (jobs).
+- Python: `pyproject.toml` / `requirements*.txt`. Note Django/Flask/FastAPI/Starlette (web), SQLAlchemy/Django ORM, Celery/RQ (workers), pandas/polars/spark (data).
+- Go: `go.mod`. Note gin/echo/chi (web), gRPC, sqlx/gorm (DB).
+- Rust: `Cargo.toml`. Note axum/actix/rocket (web), sqlx/diesel.
+- JVM: `pom.xml`/`build.gradle`. Note Spring Boot, Quarkus.
+- Ruby: `Gemfile`. Note Rails, Sidekiq.
+- PHP: `composer.json`. Note Laravel, Symfony.
+
+The stack determines L3 idioms (Phase B).
+
+### A3. Deployables / long-running processes
+
+What actually runs in production? Each one is a candidate L2 container.
+
+- `Dockerfile` files (count and per-directory).
+- `docker-compose.yml` services (each service is usually a container).
+- `Procfile` entries.
+- `serverless.yml` / `template.yaml` (SAM) functions.
+- Kubernetes manifests (`Deployment`, `StatefulSet`, `CronJob`).
+- GitHub Actions deploy jobs (look in `.github/workflows/*.yml` for `deploy`/`publish` jobs).
+- `package.json` scripts: `start`, `dev`, `serve`, `worker`, `consumer`.
+- `bin/` entry points and shebang scripts.
+
+### A4. Datastores & infra
+
+- Env vars in `.env*`, `.env.example`, `docker-compose.yml`, k8s configmaps. Watch for `*_URL`, `*_DSN`, `*_HOST`, `*_BUCKET`, `*_QUEUE`.
+- ORM configs: `prisma/schema.prisma`, Django `DATABASES` setting, `alembic.ini`, `sqlalchemy.url`, `knexfile.js`.
+- Queues: `redis`, `rabbitmq`, `kafka`, `sqs`, `pubsub` mentions in deps + env.
+- Object storage: `s3`, `gcs`, `azure-blob`.
+- IaC: `terraform/`, `cdk/`, `pulumi/`, `bicep/`. Each `aws_db_instance` / `azurerm_storage_account` / etc. is usually a node.
+
+### A5. External systems & SDKs
+
+Grep dependency manifests and import statements. Each match is usually an external L1/L2 node.
+
+| Capability    | SDK / dependency hint                                              | Suggested node                                         |
+| ------------- | ------------------------------------------------------------------ | ------------------------------------------------------ |
+| Payments      | `stripe`, `braintree`, `square`, `paddle`                          | "Stripe" — `meta.type: external`, `technology: stripe` |
+| Email         | `@sendgrid/*`, `resend`, `postmark`, `mailgun`                     | "SendGrid" — `external`                                |
+| Auth          | `next-auth`, `@clerk/*`, `@auth0/*`, `firebase-auth`, `passport-*` | "Auth0" / "Clerk" — `external`                         |
+| AI            | `openai`, `@anthropic-ai/sdk`, `cohere-ai`, `together`             | "Anthropic API" — `external`, `technology: anthropic`  |
+| Analytics     | `posthog`, `mixpanel`, `segment`, `amplitude`                      | "PostHog" — `external`                                 |
+| Observability | `@sentry/*`, `datadog`, `newrelic`                                 | "Sentry" — `external`                                  |
+| AWS           | `@aws-sdk/client-s3`, `boto3`                                      | One node per service used (S3, SQS, DynamoDB)          |
+| Search        | `@elastic/elasticsearch`, `algoliasearch`, `meilisearch`           | "Elasticsearch" — `database` or `external`             |
+| Cache         | `redis`, `ioredis`, `memcached`                                    | "Redis" — `cache`                                      |
+| CDN / files   | `cloudinary`, `uploadthing`, `imagekit`                            | `storage`                                              |
+| Webhooks in   | Routes under `/webhooks/*`, `webhook` middleware                   | edge from external SaaS → your service                 |
+
+### A6. Actors / personas
+
+Who interacts with the system from outside?
+
+- Different frontends (admin app vs end-user app vs marketing site) → different actors **or** different containers.
+- Auth roles (`admin`, `customer`, `support`) → multiple person nodes when behavior differs.
+- Public API consumers (`api.example.com`) → an external "API Consumer" person node.
+- CLI users → person node when the CLI is the primary interface.
+- CI / cron / external webhook callers → distinguish from human actors.
+
+### A7. Purpose
+
+In one paragraph from the README + the package manifest `description`. This becomes the seed for `manifest.description` and the top-system description.
+
+If the README is a wall of badges and boilerplate, fall back to: name of the deployed service + what its primary endpoint or CLI command does + who calls it.
+
+## Phase B — Map discovery → C4
+
+### Universal rules
+
+- **L1 = system context.** One node for the system itself + person actors + every external SaaS/API/datastore that lives outside _your_ deployable boundary. 3–5 nodes total. **Never** name internal services here.
+- **L2 = containers.** One node per deployable (A3) + one node per managed datastore (A4) + edges with concrete labels (`REST`, `gRPC`, `order.created`, `reads/writes`). 4–8 nodes.
+- **L3 = components.** Optional. Add only when an L2 container has 3+ separable internal parts that a reader genuinely needs to see (controllers/services/repos in a layered API; producers/consumers/state machines in a worker; pages/server-actions/middlewares in a Next.js app). 3–6 nodes.
+
+### Grouping vs. drill-down
+
+Inside any level you can also group 2–4 siblings under a labeled container using `parentId` + `meta.isContainer: true`. The rule:
+
+- **Group (`parentId`) when**: 2–4 nodes share an obvious runtime boundary on the **same level** (three controllers under one router, four workers under a pool), and the grouping reads better than leaving them flat. Edges into/out of the group still work; one level of nesting only.
+- **Drill down (`subDiagramId`) when**: the inner structure earns its own page — 3+ nodes with edges that matter only at the deeper level (an API service → its controllers/services/repos as L3).
+- **Default**: flat. Don't nest if the boundary isn't load-bearing; the reader pays for every box.
+
+### Stack recipes
+
+Concrete templates. Adjust to the actual code — these are priors, not prescriptions.
+
+#### Next.js / React + API routes
+
+- **L1** — System (your app) ← Customer; → external SaaS (Stripe, Auth0, OpenAI, S3); → Postgres if managed.
+- **L2** — `Web App` (frontend, `meta.type: frontend`, `technology: nextjs`); `API Routes` (`service`, `nextjs`) — **only split if the API surface is non-trivial; otherwise model Next.js as one container**; `Postgres` (`database`); each external SaaS as `external`.
+- **L3 (API Routes)** — group by feature folder under `app/api/*` or `pages/api/*`. One component per top-level route group (`auth`, `checkout`, `webhooks`).
+
+Example node:
+
+```jsonc
+{
+  "id": "web-app",
+  "label": "Next.js App",
+  "subDiagramId": "components-web",
+  "meta": { "type": "frontend", "technology": "nextjs" },
+}
+```
+
+#### Express / NestJS / Fastify (Node API)
+
+- **L1** — System ← Frontend(s) (often external from the API's perspective if they live in a different repo); → DB; → externals.
+- **L2** — `API Service` (`service`, `expressjs`/`nestjs`/`fastify`); `Worker` if there is a queue consumer; `Postgres`; `Redis` if used; broker if used.
+- **L3 (API Service)** — one component per top-level controller group + one for the ORM/repo layer + one for shared middleware (auth, rate-limit) when material.
+
+#### Python: Django / Rails monolith
+
+- **L1** — System ← User; → DB; → externals.
+- **L2** — `Web App` (`service`, `django`/`rails`); `Worker` (`service`, `celery`/`sidekiq`) if present; `Postgres`; `Redis` (broker/cache).
+- **L3 (Web App)** — one component per Django app / Rails engine. Don't model every model class.
+
+#### Python: FastAPI + workers
+
+- **L1** — System ← Client; → DB; → externals (often OpenAI/Anthropic, S3).
+- **L2** — `API` (`service`, `fastapi`); `Worker` (`service`, technology depending on broker); `Broker` (`queue`, `redis`/`rabbitmq`); `Postgres`.
+- **L3 (API)** — one component per `routers/*` module + a `Services` component for shared business logic + a `Repositories` component if a clean layer exists.
+
+#### Python: data pipeline / Airflow / dbt
+
+- **L1** — System (the pipeline) ← Analyst (consumer of the warehouse); ← Source systems (the upstream data); → Warehouse.
+- **L2** — One container per scheduler/runtime (`Airflow`, `dbt Cloud`, `Dagster`); `Warehouse` (Snowflake/BigQuery/Postgres) as `database`; each upstream source (Stripe export, S3 raw bucket, Kafka stream) as `external`/`storage`/`queue`.
+- **L3 (per scheduler)** — one component per DAG / model directory. Don't model every task.
+
+#### Go / Rust microservices
+
+- **L1** — System ← clients; → externals.
+- **L2** — One container per `cmd/*` (Go) / per binary in `Cargo.toml` workspace (Rust); each datastore as its own node; gRPC mesh edges between services.
+- **L3** — Optional. Use when a single service has clean internal layering (`handler` / `service` / `store`).
+
+#### Mobile (React Native / Flutter / iOS / Android)
+
+- **L1** — System (the mobile app + its backend) ← End user; → backend if separately owned; → push provider (FCM/APNs); → analytics; → auth.
+- **L2** — `Mobile App` (`frontend`, `react`/`flutter`/`swift`/`kotlin`); `Backend API`; managed datastores; push provider.
+- **L3 (Mobile App)** — feature modules / navigation stacks; only if the app is genuinely multi-feature.
+
+#### CLI / library / SDK
+
+- **L1 only.** A single system box, the user/agent who invokes it, and any service it talks to (registry, telemetry endpoint, target system). **No L2 unless the CLI is internally split into independently deployable pieces** — a CLI with `commands/` directories does not need an L2.
+- For SDKs whose main job is talking to one upstream API: model the upstream API as an external node, the SDK as the system, and the consumer (app) as the actor.
+
+#### Monorepo with multiple deployables (e.g. pnpm workspaces — this repo's shape)
+
+- **L1** — System box + actors + every external SaaS.
+- **L2** — One container per **independently runnable or published** workspace package. Skip pure type-only packages unless they cross a meaningful API boundary. Datastores and brokers as nodes.
+- **L3** — Per heaviest container only, not every container.
+
+### Anti-patterns (do not do these)
+
+- **"Business Logic" / "Service Layer" / "Helpers" nodes.** Empty calories. If you can't name what it does, it's not a node.
+- **L1 with internal service names.** `system-context.json` listing `auth-service` and `order-service` is L2 leaking into L1.
+- **L3 that just renames L2.** If the only difference between an L2 node `API` and its L3 children is "API" → "API Controller" + "API Routes", delete the L3.
+- **Edges labeled `uses`, `depends on`, `interacts with`.** Use a verb or protocol.
+- **`meta.technology` you didn't see in a manifest.** Don't add `redis` because it "feels right" — grep first.
+- **One description.md per node that all read like `<Label> handles <label>-related things`.** Fail criterion #8. Rewrite or remove.
+- **Modeling every directory.** A `utils/` folder is not a component. A `models/` folder is not a database.
+- **Modeling tests, lint configs, CI jobs as nodes.** Those are not part of the runtime architecture. (CI/CD platforms only appear as nodes if the architecture is _about_ delivery, e.g. a release-automation system.)
+- **Forking the architecture into "logical" + "physical".** Pick one — Tecture diagrams represent _what runs_. Use `meta.type` (`service`, `database`, `queue`, etc.) to convey the physical reality.
+
+## Phase C — Author & self-evaluate
+
+After Phase B you have a list of nodes and edges in your head (or in a scratch buffer). Now write files in this order:
+
+1. **L3 diagrams first** (if any) — children before parents so slugs exist for `subDiagramId`.
+2. **L2 diagram(s).** Set `subDiagramId` on each container that has an L3.
+3. **L1 diagram.** Set `subDiagramId` on the system node pointing at the L2 slug.
+4. **Descriptions** — one `descriptions/<id>.md` per node id used anywhere. Lead with one sentence of _responsibility_ (criterion #8). Add `## Responsibilities` and `## Tech Stack` sections. Add a Mermaid sub-diagram only when the prose is genuinely easier to grasp visually (sequence, state machine, fan-out).
+5. **`manifest.json`** — `name`, `description` (2–4 plain-text paragraphs), `topDiagram` set to the L1 slug, `diagrams` listing every slug.
+
+Then run the **quality checklist** (12 items in [SKILL.md](../SKILL.md#quality-checklist)) and the validator. Fix everything before reporting success.
+
+## Worked example: discovering Tecture IO itself
+
+Applied to the [architecture/](../../../../architecture/) folder of this repo. Use this as a reference for the level of evidence you should be gathering.
+
+**A1. Repo shape** — Monorepo with one published deployable. `pnpm-workspace.yaml` lists `packages/shared`, `packages/web`, `packages/server`. Only `packages/server` (`@tecture/core`) is published; `packages/web` and `packages/shared` are bundled into it at build time (per the README "Repo layout" table).
+
+**A2. Stack** — Node 20+, Express (server), React + Vite + ReactFlow + ELK (web), TypeScript types (shared). pnpm 10 monorepo via Corepack.
+
+**A3. Deployables** — One: the published CLI `@tecture/core`, started by `npx @tecture/core` on port 3000. Serves both REST API and bundled UI from a single Express process.
+
+**A4. Datastores & infra** — None. Per the README: "no database, no authentication, no deployment surface — the only durable state lives on the user's local filesystem."
+
+**A5. External systems** — None directly called. The user's local `architecture/` directory is the only data source — model it as an external `storage` node.
+
+**A6. Actors** — Developer (runs the CLI, browses diagrams). Coding agent (writes the `architecture/` files, indirectly upstream of the viewer).
+
+**A7. Purpose** — From `manifest.json` description: "zero-configuration viewer for file-based architecture diagrams authored by coding agents."
+
+**Mapping** (Phase B):
+
+- L1: `developer` (person) → `tecture-io` (system) ← `coding-agent` (person, writes the files); `tecture-io` → `architecture-files` (external storage).
+- L2: `cli-server` (service, expressjs) — bundles and serves the UI; `web-ui` (frontend, react) — rendered ReactFlow canvas; `shared-types` only if you want to show the contract between server and UI; `architecture-files` (storage) on the user's local disk.
+- L3: per container only if needed. The server has clear internal seams (REST routes, the file reader, the manifest parser); the UI has the diagram view, the description panel, the routing layer.
+
+This matches the existing [architecture/manifest.json](../../../../architecture/manifest.json) (`system-context`, `containers`, `components-api`, `components-web`) — meaning the discovery process re-derives a known-good architecture from first principles, which is the bar new outputs should clear.

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/admin-app.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/admin-app.md
@@ -1,0 +1,10 @@
+Authenticated React SPA used by store owners to manage catalog and orders.
+
+## Responsibilities
+
+- CRUD on products and categories
+- View and update order statuses
+
+## Tech Stack
+
+- React, Vite

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/api-service.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/api-service.md
@@ -1,0 +1,26 @@
+Node.js REST API backing both the storefront and the admin app.
+
+## Responsibilities
+
+- Authentication and session management
+- Catalog reads and mutations
+- Order creation (publishes `order.created` to the event bus)
+
+## Tech Stack
+
+- Node.js, Express, Prisma
+
+## Order Creation Flow
+
+```mermaid
+sequenceDiagram
+  participant SF as Storefront
+  participant API as API Service
+  participant DB as Postgres
+  participant EB as Event Bus
+  SF->>API: POST /orders
+  API->>DB: INSERT order
+  DB-->>API: order id
+  API->>EB: publish order.created
+  API-->>SF: 201 Created
+```

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/auth-controller.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/auth-controller.md
@@ -1,0 +1,6 @@
+HTTP entry point for sign-in, sign-up, and session endpoints.
+
+## Responsibilities
+
+- Validate credentials and issue session tokens
+- Refresh and revoke tokens

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/catalog-controller.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/catalog-controller.md
@@ -1,0 +1,6 @@
+HTTP endpoints for reading and mutating the product catalog.
+
+## Responsibilities
+
+- List / get / search products
+- Admin-only catalog writes

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/catalog-repo.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/catalog-repo.md
@@ -1,0 +1,6 @@
+Data-access layer wrapping catalog tables in PostgreSQL.
+
+## Responsibilities
+
+- Type-safe reads/writes over products and categories
+- Centralize query building and mapping

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/controllers.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/controllers.md
@@ -1,0 +1,11 @@
+Express/Fastify router layer that owns all HTTP entry points for the API service. Auth, catalog, and order controllers live here; each one parses and validates a request, then delegates to a service or repository.
+
+## Responsibilities
+
+- Mount route handlers under `/auth`, `/catalog`, and `/orders`
+- Enforce auth middleware and request schema validation before handlers run
+- Translate domain errors into HTTP status codes
+
+## Tech Stack
+
+- Express 4 + zod for schema validation

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/customer.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/customer.md
@@ -1,0 +1,7 @@
+Shoppers who browse the public storefront and place orders.
+
+## Responsibilities
+
+- Browse product catalog
+- Add items to cart and check out
+- Receive order confirmations

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/ecommerce.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/ecommerce.md
@@ -1,0 +1,11 @@
+The e-commerce platform that hosts the storefront, admin tools, and order processing pipeline.
+
+## Responsibilities
+
+- Serve the public storefront
+- Handle authenticated store-owner admin flows
+- Process and fulfill orders
+
+## Tech Stack
+
+- Next.js, Node.js, PostgreSQL, RabbitMQ

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/event-bus.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/event-bus.md
@@ -1,0 +1,10 @@
+Message broker carrying order-lifecycle events between services.
+
+## Responsibilities
+
+- Deliver `order.created` events from the API to the order worker
+- Durable queuing for retry and backpressure
+
+## Tech Stack
+
+- RabbitMQ

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/order-controller.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/order-controller.md
@@ -1,0 +1,7 @@
+HTTP entry point for order creation and lookup.
+
+## Responsibilities
+
+- Accept checkout requests
+- Delegate to the order service
+- Return order status to the caller

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/order-service.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/order-service.md
@@ -1,0 +1,7 @@
+Domain-layer module coordinating order placement.
+
+## Responsibilities
+
+- Validate order inputs against the catalog
+- Persist new orders
+- Publish `order.created` to the event bus

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/postgres.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/postgres.md
@@ -1,0 +1,10 @@
+Primary transactional database.
+
+## Responsibilities
+
+- Source of truth for users, products, orders
+- Accessed by the API service and the order worker
+
+## Tech Stack
+
+- PostgreSQL 16

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/store-owner.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/store-owner.md
@@ -1,0 +1,7 @@
+Merchants who configure the store and manage the product catalog through the admin app.
+
+## Responsibilities
+
+- Maintain product catalog
+- Review incoming orders
+- Configure store settings

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/storefront.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/storefront.md
@@ -1,0 +1,10 @@
+Public Next.js web app that customers use to browse and buy products.
+
+## Responsibilities
+
+- Render catalog and product pages
+- Run client-side cart and checkout
+
+## Tech Stack
+
+- Next.js (App Router), React Server Components

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/stripe.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/stripe.md
@@ -1,0 +1,6 @@
+Third-party payment processor used to charge customers during checkout.
+
+## Responsibilities
+
+- Authorize and capture card payments
+- Return payment status to the API service

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/worker.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/descriptions/worker.md
@@ -1,0 +1,11 @@
+Background worker that consumes order events and runs fulfillment side effects.
+
+## Responsibilities
+
+- Subscribe to `order.created`
+- Trigger payment capture and fulfillment
+- Write order status updates back to Postgres
+
+## Tech Stack
+
+- Node.js

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/diagrams/api-components.json
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/diagrams/api-components.json
@@ -1,0 +1,41 @@
+{
+  "name": "API Service — Components",
+  "level": 3,
+  "meta": { "direction": "LR" },
+  "nodes": [
+    { "id": "controllers", "label": "HTTP Controllers", "meta": { "type": "gateway", "isContainer": true } },
+    { "id": "auth-controller", "label": "Auth Controller", "parentId": "controllers", "meta": { "type": "service" } },
+    {
+      "id": "catalog-controller",
+      "label": "Catalog Controller",
+      "parentId": "controllers",
+      "meta": { "type": "service" }
+    },
+    { "id": "order-controller", "label": "Order Controller", "parentId": "controllers", "meta": { "type": "service" } },
+    { "id": "order-service", "label": "Order Service", "meta": { "type": "service" } },
+    { "id": "catalog-repo", "label": "Catalog Repository", "meta": { "type": "database" } }
+  ],
+  "edges": [
+    {
+      "id": "e-order-ctrl-order-svc",
+      "source": "order-controller",
+      "target": "order-service",
+      "label": "invokes",
+      "meta": { "type": "calls" }
+    },
+    {
+      "id": "e-catalog-ctrl-repo",
+      "source": "catalog-controller",
+      "target": "catalog-repo",
+      "label": "reads",
+      "meta": { "type": "reads" }
+    },
+    {
+      "id": "e-order-svc-catalog",
+      "source": "order-service",
+      "target": "catalog-repo",
+      "label": "reads",
+      "meta": { "type": "reads" }
+    }
+  ]
+}

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/diagrams/containers.json
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/diagrams/containers.json
@@ -1,0 +1,62 @@
+{
+  "name": "Containers",
+  "level": 2,
+  "meta": { "direction": "TB" },
+  "nodes": [
+    { "id": "storefront", "label": "Storefront Web", "meta": { "type": "frontend", "technology": "nextjs" } },
+    { "id": "admin-app", "label": "Admin Web", "meta": { "type": "frontend", "technology": "react" } },
+    {
+      "id": "api-service",
+      "label": "API Service",
+      "subDiagramId": "api-components",
+      "meta": { "type": "service", "technology": "nodedotjs" }
+    },
+    { "id": "postgres", "label": "PostgreSQL", "meta": { "type": "database", "technology": "postgresql" } },
+    { "id": "event-bus", "label": "Event Bus", "meta": { "type": "queue", "technology": "rabbitmq" } },
+    { "id": "worker", "label": "Order Worker", "meta": { "type": "service", "technology": "nodedotjs" } }
+  ],
+  "edges": [
+    {
+      "id": "e-storefront-api",
+      "source": "storefront",
+      "target": "api-service",
+      "label": "REST",
+      "meta": { "type": "calls" }
+    },
+    {
+      "id": "e-admin-api",
+      "source": "admin-app",
+      "target": "api-service",
+      "label": "REST",
+      "meta": { "type": "calls" }
+    },
+    {
+      "id": "e-api-postgres",
+      "source": "api-service",
+      "target": "postgres",
+      "label": "reads/writes",
+      "meta": { "type": "writes" }
+    },
+    {
+      "id": "e-api-eventbus",
+      "source": "api-service",
+      "target": "event-bus",
+      "label": "order.created",
+      "meta": { "type": "publishes" }
+    },
+    {
+      "id": "e-worker-eventbus",
+      "source": "worker",
+      "target": "event-bus",
+      "label": "order.created",
+      "meta": { "type": "subscribes" }
+    },
+    {
+      "id": "e-worker-postgres",
+      "source": "worker",
+      "target": "postgres",
+      "label": "updates",
+      "meta": { "type": "writes" }
+    }
+  ]
+}

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/diagrams/system-context.json
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/diagrams/system-context.json
@@ -1,0 +1,34 @@
+{
+  "name": "System Context",
+  "level": 1,
+  "meta": { "direction": "TB" },
+  "nodes": [
+    { "id": "customer", "label": "Customer", "meta": { "type": "external" } },
+    { "id": "store-owner", "label": "Store Owner", "meta": { "type": "external" } },
+    { "id": "ecommerce", "label": "E-Commerce Platform", "subDiagramId": "containers", "meta": { "type": "system" } },
+    { "id": "stripe", "label": "Stripe", "meta": { "type": "external", "technology": "stripe" } }
+  ],
+  "edges": [
+    {
+      "id": "e-customer-ecommerce",
+      "source": "customer",
+      "target": "ecommerce",
+      "label": "browses and buys",
+      "meta": { "type": "calls" }
+    },
+    {
+      "id": "e-store-owner-ecommerce",
+      "source": "store-owner",
+      "target": "ecommerce",
+      "label": "manages catalog",
+      "meta": { "type": "calls" }
+    },
+    {
+      "id": "e-ecommerce-stripe",
+      "source": "ecommerce",
+      "target": "stripe",
+      "label": "processes payments",
+      "meta": { "type": "calls" }
+    }
+  ]
+}

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/example/manifest.json
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/example/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "E-Commerce Platform",
+  "description": "A small e-commerce platform that lets store owners manage a product catalog and customers browse and purchase items.\n\nThe backend is split into a handful of services communicating via REST, with an event bus for order notifications. Data lives in PostgreSQL.\n\nDeployed on a single cloud provider using managed services where possible.",
+  "topDiagram": "system-context",
+  "diagrams": ["system-context", "containers", "api-components"]
+}

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/schema.md
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/schema.md
@@ -1,0 +1,161 @@
+# File-Based Architecture Schema
+
+Detailed reference for the file layout and JSON schemas used by the `architecture-files` skill.
+
+This is the file-based mirror of the Tecture database schema documented in [/docs/ARCHITECTURE.md](/docs/ARCHITECTURE.md) and [/docs/DIAGRAM_SCHEMA.md](/docs/DIAGRAM_SCHEMA.md). The key differences:
+
+- UUIDs are replaced with kebab-case **slugs** (diagram file names; stable node ids).
+- Node `description` is not inlined in JSON — it lives in `descriptions/<node-id>.md`.
+- Manual `positions` and other viewer state are not stored (the web viewer rebuilds layout on import).
+
+## Directory layout
+
+```
+architecture/
+├── manifest.json
+├── diagrams/
+│   └── <diagram-slug>.json
+└── descriptions/
+    └── <node-id>.md
+```
+
+All paths are relative to the architecture root (default `./architecture` at project root).
+
+## `manifest.json`
+
+Draft 2020-12 JSON Schema: [../schemas/manifest.schema.json](../schemas/manifest.schema.json).
+
+| Field         | Type   | Required | Notes                                                                    |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------ |
+| `name`        | string | yes      | Architecture name.                                                       |
+| `description` | string | no       | Plain-text, 2–4 paragraphs separated by `\n\n`. No markdown.             |
+| `topDiagram`  | slug   | yes      | Slug of the entry-point diagram. Must appear in `diagrams[]`.            |
+| `diagrams`    | slug[] | yes      | Every diagram slug that belongs to this architecture. Non-empty, unique. |
+
+Unknown top-level fields are rejected. Slugs match `^[a-z0-9]+(-[a-z0-9]+)*$`.
+
+## `diagrams/<slug>.json`
+
+Draft 2020-12 JSON Schema: [../schemas/diagram.schema.json](../schemas/diagram.schema.json).
+
+### Top-level
+
+| Field            | Type             | Required | Notes                                                                                 |
+| ---------------- | ---------------- | -------- | ------------------------------------------------------------------------------------- |
+| `name`           | string           | yes      | Human-readable diagram title (e.g. `"System Context"`, `"API Service – Components"`). |
+| `level`          | 1 \| 2 \| 3      | no       | C4 level hint. 1 = System Context, 2 = Container, 3 = Component.                      |
+| `meta.direction` | `"TB"` \| `"LR"` | no       | Layout direction. Default `TB`.                                                       |
+| `meta.layout`    | string           | no       | Layout engine hint (opaque to the skill).                                             |
+| `nodes`          | Node[]           | yes      | Non-empty.                                                                            |
+| `edges`          | Edge[]           | no       | Defaults to `[]`.                                                                     |
+
+### Node
+
+| Field              | Type         | Required | Notes                                                                                                                                                                                                                                                                                  |
+| ------------------ | ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`               | slug         | yes      | **Globally unique** across every diagram in the architecture. Matches the filename under `descriptions/`.                                                                                                                                                                              |
+| `label`            | string       | yes      | Display name.                                                                                                                                                                                                                                                                          |
+| `parentId`         | slug \| null | no       | Another node's `id` **in the same diagram** whose `meta.isContainer = true`. Groups 2–4 sibling nodes under a labeled container. One level of nesting only — grandchildren are rejected; use `subDiagramId` for deeper decomposition. See [How diagrams relate](#how-diagrams-relate). |
+| `subDiagramId`     | slug \| null | no       | Another diagram's slug (drill-down target). Must exist under `diagrams/`. Self-reference is forbidden. See [How diagrams relate](#how-diagrams-relate).                                                                                                                                |
+| `meta.type`        | enum         | no       | One of `system`, `person`, `service`, `database`, `queue`, `gateway`, `frontend`, `cache`, `storage`, `external`.                                                                                                                                                                      |
+| `meta.technology`  | slug         | no       | Free-form tech identity, ideally a [Simple Icons](https://simpleicons.org) slug (`postgresql`, `react`, `aws-s3`).                                                                                                                                                                     |
+| `meta.isContainer` | boolean      | no       | If `true`, this node groups child nodes (those that set `parentId` to this id).                                                                                                                                                                                                        |
+
+Nodes **must not** carry a `description` field — descriptions live in `descriptions/<id>.md`.
+
+### Edge
+
+| Field       | Type   | Required | Notes                                                                                   |
+| ----------- | ------ | -------- | --------------------------------------------------------------------------------------- |
+| `id`        | slug   | yes      | Unique within the diagram. Convention: `e-<source>-<target>`.                           |
+| `source`    | string | yes      | Must match a node `id` in the same diagram.                                             |
+| `target`    | string | yes      | Must match a node `id` in the same diagram.                                             |
+| `label`     | string | no       | Short relationship label (`"REST API"`, `"gRPC"`, `"reads/writes"`, `"order.created"`). |
+| `meta.type` | enum   | no       | One of `calls`, `reads`, `writes`, `publishes`, `subscribes`, `data-flow`.              |
+
+Edges cannot cross diagram boundaries. Cross-level relationships are expressed with `subDiagramId`, not edges.
+
+## `descriptions/<node-id>.md`
+
+GitHub-flavored markdown. No required structure, but the convention is:
+
+```markdown
+One- or two-sentence summary of what this component does.
+
+## Responsibilities
+
+- …
+- …
+
+## Tech Stack
+
+- …
+```
+
+Filename must be exactly `<node.id>.md`. Orphan files (no matching node id anywhere) generate a warning.
+
+### Mermaid diagrams
+
+Any fenced block tagged `mermaid` is rendered as an SVG diagram inside the viewer's node detail panel and can be enlarged in a full-screen lightbox. Use this to describe behavior the static C4 diagrams don't show: request/response sequences, lifecycle/state transitions, data flow with branches, queue fan-out, retry logic.
+
+- Supported: every mermaid diagram type (`sequenceDiagram`, `flowchart`, `stateDiagram-v2`, `erDiagram`, `classDiagram`, `gantt`, `journey`, `gitGraph`, `mindmap`, etc.). The viewer bundles the full mermaid distribution.
+- Rendering is sandboxed (`securityLevel: "strict"`) — click handlers and inline HTML inside mermaid source are ignored. Stick to standard mermaid syntax.
+- Theme variables are set by the viewer to match the blueprint palette (dark background, cyan/blue/emerald accents, mono font). Don't try to override them from inside the fence.
+- Style guidance: keep each chart focused (5–10 participants/states). Prefer one chart per description — if a description grows several charts, the underlying component is probably doing too much and should be split into finer nodes.
+- Validation is syntactic only (the prose is GFM). Malformed mermaid syntax will surface as an amber error card with the source preserved when the viewer tries to render it.
+
+Example:
+
+````markdown
+Stripe webhook receiver that reconciles payment state.
+
+## Retry Flow
+
+```mermaid
+stateDiagram-v2
+  [*] --> Pending
+  Pending --> Confirmed: webhook.succeeded
+  Pending --> Failed: webhook.failed
+  Failed --> Pending: retry (<= 3)
+  Failed --> [*]: give up (> 3)
+  Confirmed --> [*]
+```
+````
+
+## How diagrams relate
+
+Three mechanisms, each with a distinct job:
+
+1. **Manifest grouping** — `manifest.diagrams[]` lists sibling diagrams in one architecture. `manifest.topDiagram` identifies the entry point.
+2. **Nesting within a diagram (`parentId`)** — a node groups 2–4 sibling nodes under a container (`meta.isContainer: true`). The viewer renders the parent as a labeled boundary with its children laid out inside. One level deep only. Use when the grouping is a runtime boundary (controllers under a router, workers under a pool) but doesn't earn its own page.
+3. **Cross-diagram drill-down (`subDiagramId`)** — a node points at another diagram's slug. Clicking it navigates into that diagram. Use when the inner structure is complex enough (3+ nodes with their own edges) to deserve its own page. The drill-down graph must be acyclic.
+
+**Decision rule.**
+
+- 2–4 things share an obvious runtime boundary, on the same level? → `parentId`.
+- 3+ things warrant their own page, with edges only the reader at that level should see? → `subDiagramId`.
+- Default: flat. Don't nest or drill down unless the grouping is load-bearing.
+
+A parent in `parentId` is **not** a substitute for a container node in a C4 level — it's a visual grouping of siblings on the same level. The parent itself still needs a `descriptions/<id>.md`.
+
+## Canonical authoring order
+
+Create children before parents, because parents reference child slugs:
+
+1. Write L3 diagrams (if any) and their node description files.
+2. Write L2 (Container) diagrams, set `subDiagramId` on nodes pointing at L3 slugs, and their description files.
+3. Write L1 (System Context) diagram, set `subDiagramId` on the main system node pointing at the L2 slug, and its description files.
+4. Write `manifest.json` with `diagrams[]` containing every slug and `topDiagram` set to the L1 slug.
+5. Run the validator (`node scripts/validate.mjs`).
+
+## Validation rules (what the script checks)
+
+- Every JSON file parses and matches its JSON Schema (shape, enums, slugs, no unknown fields).
+- `manifest.topDiagram` is present in `manifest.diagrams`.
+- Every slug in `manifest.diagrams` has a file; every file on disk is listed (unlisted files → warning).
+- Every `node.parentId` resolves to a same-diagram node with `meta.isContainer = true`; the `parentId` chain is acyclic and at most one level deep (grandchildren rejected).
+- Every `node.subDiagramId` resolves to an existing diagram and is not self-referential.
+- Every `edge.source` / `edge.target` resolves to a same-diagram node.
+- Node ids are globally unique across all diagrams.
+- Every node id has a matching `descriptions/<id>.md` (missing → error, orphan → warning).
+- The drill-down graph formed by `subDiagramId` is a DAG (no cycles).

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/schemas/diagram.schema.json
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/schemas/diagram.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "tecture://schema/diagram",
+  "title": "C4 Diagram",
+  "description": "One level of a C4 architecture diagram (nodes + edges).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "nodes"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "level": {
+      "type": "integer",
+      "enum": [1, 2, 3],
+      "description": "C4 level: 1=System Context, 2=Container, 3=Component."
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "direction": { "enum": ["TB", "LR"] },
+        "layout": { "type": "string" }
+      }
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/Node" }
+    },
+    "edges": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Edge" }
+    }
+  },
+  "$defs": {
+    "Node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Globally unique kebab-case slug. Matches the filename under descriptions/."
+        },
+        "label": { "type": "string", "minLength": 1 },
+        "parentId": {
+          "type": ["string", "null"],
+          "description": "Another node id in this same diagram whose meta.isContainer is true."
+        },
+        "subDiagramId": {
+          "type": ["string", "null"],
+          "description": "Slug of another diagram file (drill-down target)."
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "enum": [
+                "system",
+                "person",
+                "service",
+                "database",
+                "queue",
+                "gateway",
+                "frontend",
+                "cache",
+                "storage",
+                "external"
+              ]
+            },
+            "technology": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+            },
+            "isContainer": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "Edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source", "target"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+        },
+        "source": { "type": "string" },
+        "target": { "type": "string" },
+        "label": { "type": "string" },
+        "meta": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "enum": ["calls", "reads", "writes", "publishes", "subscribes", "data-flow"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/skills-catalog/skills/(architecture)/tecture/references/schemas/manifest.schema.json
+++ b/packages/skills-catalog/skills/(architecture)/tecture/references/schemas/manifest.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "tecture://schema/manifest",
+  "title": "Architecture Manifest",
+  "description": "Top-level manifest for a file-based Tecture architecture.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "topDiagram", "diagrams"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable architecture name."
+    },
+    "description": {
+      "type": "string",
+      "description": "Plain-text description (2-4 paragraphs, separated by \\n\\n). No markdown."
+    },
+    "topDiagram": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Slug of the entry-point diagram (file name under diagrams/ without .json). Kebab-case."
+    },
+    "diagrams": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+      },
+      "description": "All diagram slugs that belong to this architecture."
+    }
+  }
+}

--- a/packages/skills-catalog/skills/(architecture)/tecture/scripts/validate.mjs
+++ b/packages/skills-catalog/skills/(architecture)/tecture/scripts/validate.mjs
@@ -1,0 +1,435 @@
+#!/usr/bin/env node
+/* global console, process */
+// Validator for file-based Tecture architectures.
+// Usage: node validate.mjs [path/to/architecture]
+// Exits 0 on success, 1 on validation failure, 2 on internal error.
+
+import { constants as FS } from 'node:fs'
+import { access, readFile, readdir } from 'node:fs/promises'
+import { basename, extname, join, resolve } from 'node:path'
+
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+const NODE_TYPES = new Set([
+  'system',
+  'person',
+  'service',
+  'database',
+  'queue',
+  'gateway',
+  'frontend',
+  'cache',
+  'storage',
+  'external',
+])
+const EDGE_TYPES = new Set(['calls', 'reads', 'writes', 'publishes', 'subscribes', 'data-flow'])
+const DIRECTIONS = new Set(['TB', 'LR'])
+const LEVELS = new Set([1, 2, 3])
+
+class Report {
+  constructor() {
+    this.errors = []
+    this.warnings = []
+  }
+  err(where, msg) {
+    this.errors.push(`[error] ${where}: ${msg}`)
+  }
+  warn(where, msg) {
+    this.warnings.push(`[warn]  ${where}: ${msg}`)
+  }
+  get ok() {
+    return this.errors.length === 0
+  }
+  print() {
+    for (const w of this.warnings) console.warn(w)
+    for (const e of this.errors) console.error(e)
+    const summary = this.ok
+      ? `OK — ${this.warnings.length} warning(s)`
+      : `FAIL — ${this.errors.length} error(s), ${this.warnings.length} warning(s)`
+    ;(this.ok ? console.log : console.error)(summary)
+  }
+}
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v)
+const isStr = (v) => typeof v === 'string'
+const isBool = (v) => typeof v === 'boolean'
+const isInt = (v) => Number.isInteger(v)
+
+async function exists(p) {
+  try {
+    await access(p, FS.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function loadJson(path) {
+  const raw = await readFile(path, 'utf8')
+  try {
+    return JSON.parse(raw)
+  } catch (e) {
+    throw new Error(`Invalid JSON in ${path}: ${e.message}`)
+  }
+}
+
+function validateManifest(m, report) {
+  const where = 'manifest.json'
+  if (!isObj(m)) return report.err(where, 'must be an object')
+
+  const allowed = new Set(['name', 'description', 'topDiagram', 'diagrams'])
+  for (const k of Object.keys(m)) {
+    if (!allowed.has(k)) report.err(where, `unknown field "${k}"`)
+  }
+
+  if (!isStr(m.name) || m.name.length === 0) report.err(where, 'missing or empty name')
+  if ('description' in m && !isStr(m.description)) report.err(where, 'description must be a string')
+  if (!isStr(m.topDiagram) || !SLUG_RE.test(m.topDiagram)) {
+    report.err(where, 'topDiagram must be a kebab-case slug')
+  }
+  if (!Array.isArray(m.diagrams) || m.diagrams.length === 0) {
+    report.err(where, 'diagrams must be a non-empty array')
+    return
+  }
+  const seen = new Set()
+  for (const s of m.diagrams) {
+    if (!isStr(s) || !SLUG_RE.test(s)) report.err(where, `invalid diagram slug: ${JSON.stringify(s)}`)
+    if (seen.has(s)) report.err(where, `duplicate diagram slug: ${s}`)
+    seen.add(s)
+  }
+  if (isStr(m.topDiagram) && !seen.has(m.topDiagram)) {
+    report.err(where, `topDiagram "${m.topDiagram}" is not listed in diagrams[]`)
+  }
+}
+
+function validateDiagramShape(slug, d, report) {
+  const where = `diagrams/${slug}.json`
+  if (!isObj(d)) {
+    report.err(where, 'must be an object')
+    return false
+  }
+
+  const allowed = new Set(['name', 'level', 'meta', 'nodes', 'edges'])
+  for (const k of Object.keys(d)) {
+    if (!allowed.has(k)) report.err(where, `unknown field "${k}"`)
+  }
+
+  if (!isStr(d.name) || d.name.length === 0) report.err(where, 'missing or empty name')
+  if ('level' in d && !(isInt(d.level) && LEVELS.has(d.level))) {
+    report.err(where, 'level must be 1, 2, or 3')
+  }
+  if ('meta' in d) {
+    if (!isObj(d.meta)) report.err(where, 'meta must be an object')
+    else {
+      if ('direction' in d.meta && !DIRECTIONS.has(d.meta.direction)) {
+        report.err(where, 'meta.direction must be "TB" or "LR"')
+      }
+      if ('layout' in d.meta && !isStr(d.meta.layout)) {
+        report.err(where, 'meta.layout must be a string')
+      }
+    }
+  }
+  if (!Array.isArray(d.nodes) || d.nodes.length === 0) {
+    report.err(where, 'nodes must be a non-empty array')
+    return false
+  }
+  if ('edges' in d && !Array.isArray(d.edges)) {
+    report.err(where, 'edges must be an array')
+  }
+
+  const nodeIds = new Set()
+  for (const [i, n] of d.nodes.entries()) {
+    const nw = `${where}#nodes[${i}]`
+    if (!isObj(n)) {
+      report.err(nw, 'must be an object')
+      continue
+    }
+    const nodeAllowed = new Set(['id', 'label', 'parentId', 'subDiagramId', 'meta'])
+    for (const k of Object.keys(n)) {
+      if (!nodeAllowed.has(k)) report.err(nw, `unknown field "${k}"`)
+    }
+    if (!isStr(n.id) || !SLUG_RE.test(n.id)) report.err(nw, 'id must be a kebab-case slug')
+    else if (nodeIds.has(n.id)) report.err(nw, `duplicate node id "${n.id}" within diagram`)
+    else nodeIds.add(n.id)
+    if (!isStr(n.label) || n.label.length === 0) report.err(nw, 'missing or empty label')
+    if ('parentId' in n && n.parentId !== null && !isStr(n.parentId)) {
+      report.err(nw, 'parentId must be a string or null')
+    }
+    if ('subDiagramId' in n && n.subDiagramId !== null && (!isStr(n.subDiagramId) || !SLUG_RE.test(n.subDiagramId))) {
+      report.err(nw, 'subDiagramId must be a kebab-case slug or null')
+    }
+    if ('meta' in n) {
+      if (!isObj(n.meta)) report.err(nw, 'meta must be an object')
+      else {
+        if ('type' in n.meta && !NODE_TYPES.has(n.meta.type)) {
+          report.err(nw, `meta.type "${n.meta.type}" is not a valid node type`)
+        }
+        if ('technology' in n.meta && (!isStr(n.meta.technology) || !SLUG_RE.test(n.meta.technology))) {
+          report.err(nw, 'meta.technology must be a kebab-case slug')
+        }
+        if ('isContainer' in n.meta && !isBool(n.meta.isContainer)) {
+          report.err(nw, 'meta.isContainer must be boolean')
+        }
+      }
+    }
+  }
+
+  const edges = d.edges ?? []
+  const edgeIds = new Set()
+  for (const [i, e] of edges.entries()) {
+    const ew = `${where}#edges[${i}]`
+    if (!isObj(e)) {
+      report.err(ew, 'must be an object')
+      continue
+    }
+    const edgeAllowed = new Set(['id', 'source', 'target', 'label', 'meta'])
+    for (const k of Object.keys(e)) {
+      if (!edgeAllowed.has(k)) report.err(ew, `unknown field "${k}"`)
+    }
+    if (!isStr(e.id) || !SLUG_RE.test(e.id)) report.err(ew, 'id must be a kebab-case slug')
+    else if (edgeIds.has(e.id)) report.err(ew, `duplicate edge id "${e.id}"`)
+    else edgeIds.add(e.id)
+    if (!isStr(e.source)) report.err(ew, 'source must be a string')
+    if (!isStr(e.target)) report.err(ew, 'target must be a string')
+    if ('label' in e && !isStr(e.label)) report.err(ew, 'label must be a string')
+    if ('meta' in e) {
+      if (!isObj(e.meta)) report.err(ew, 'meta must be an object')
+      else if ('type' in e.meta && !EDGE_TYPES.has(e.meta.type)) {
+        report.err(ew, `meta.type "${e.meta.type}" is not a valid edge type`)
+      }
+    }
+  }
+
+  return true
+}
+
+function validateDiagramReferences(slug, d, report, allSlugs, descriptionsAvailable, allNodeIds) {
+  const where = `diagrams/${slug}.json`
+  const nodes = d.nodes ?? []
+  const edges = d.edges ?? []
+  const nodesById = new Map(nodes.filter((n) => isStr(n?.id)).map((n) => [n.id, n]))
+
+  for (const [i, n] of nodes.entries()) {
+    const nw = `${where}#nodes[${i}]`
+    if (!isStr(n?.id)) continue
+
+    if (allNodeIds.has(n.id) && allNodeIds.get(n.id) !== slug) {
+      report.err(
+        nw,
+        `node id "${n.id}" is also used in diagrams/${allNodeIds.get(n.id)}.json — node ids must be globally unique`,
+      )
+    } else {
+      allNodeIds.set(n.id, slug)
+    }
+
+    if (n.parentId) {
+      const parent = nodesById.get(n.parentId)
+      if (!parent) report.err(nw, `parentId "${n.parentId}" does not match any node in this diagram`)
+      else if (!parent.meta?.isContainer) {
+        report.err(
+          nw,
+          `parentId "${n.parentId}" points to a node that is not a container (set parent's meta.isContainer = true)`,
+        )
+      }
+    }
+    if (n.subDiagramId) {
+      if (!allSlugs.has(n.subDiagramId)) {
+        report.err(nw, `subDiagramId "${n.subDiagramId}" is not a known diagram slug`)
+      }
+      if (n.subDiagramId === slug) {
+        report.err(nw, `subDiagramId points to the same diagram (self-reference)`)
+      }
+    }
+
+    if (!descriptionsAvailable.has(n.id)) {
+      report.err(nw, `missing description file: descriptions/${n.id}.md`)
+    }
+  }
+
+  validateNestingDepthAndCycles(slug, nodes, nodesById, report)
+
+  for (const [i, e] of edges.entries()) {
+    const ew = `${where}#edges[${i}]`
+    if (!isStr(e?.source) || !isStr(e?.target)) continue
+    if (!nodesById.has(e.source)) report.err(ew, `edge source "${e.source}" does not match any node in this diagram`)
+    if (!nodesById.has(e.target)) report.err(ew, `edge target "${e.target}" does not match any node in this diagram`)
+  }
+}
+
+// Enforces: parentId chain is acyclic and nests at most one level deep.
+// Depth 0 = top-level, depth 1 = child of a container. Depth >= 2 (grandchild) is an error.
+// Deeper decomposition should use subDiagramId (a separate child diagram).
+const MAX_NESTING_DEPTH = 1
+
+function validateNestingDepthAndCycles(slug, nodes, nodesById, report) {
+  const where = `diagrams/${slug}.json`
+  const depthCache = new Map()
+  const cycleReported = new Set()
+
+  function depthOf(id, visiting) {
+    if (depthCache.has(id)) return depthCache.get(id)
+    if (visiting.has(id)) {
+      if (!cycleReported.has(id)) {
+        const cycle = [...visiting, id]
+        const start = cycle.indexOf(id)
+        report.err(where, `parentId cycle: ${cycle.slice(start).join(' → ')}`)
+        for (const c of cycle.slice(start)) cycleReported.add(c)
+      }
+      return Infinity
+    }
+    const n = nodesById.get(id)
+    if (!n?.parentId) {
+      depthCache.set(id, 0)
+      return 0
+    }
+    if (!nodesById.has(n.parentId)) {
+      depthCache.set(id, 0)
+      return 0
+    }
+    visiting.add(id)
+    const parentDepth = depthOf(n.parentId, visiting)
+    visiting.delete(id)
+    const d = parentDepth === Infinity ? Infinity : parentDepth + 1
+    depthCache.set(id, d)
+    return d
+  }
+
+  for (const [i, n] of nodes.entries()) {
+    if (!isStr(n?.id)) continue
+    const d = depthOf(n.id, new Set())
+    if (d !== Infinity && d > MAX_NESTING_DEPTH) {
+      const nw = `${where}#nodes[${i}]`
+      report.err(
+        nw,
+        `nesting too deep (${d} levels via parentId chain; max ${MAX_NESTING_DEPTH}) — use subDiagramId to push deeper decomposition into a child diagram`,
+      )
+    }
+  }
+}
+
+function detectDrillDownCycles(diagrams, report) {
+  // Build edges: diagramSlug -> set of child diagram slugs via any node.subDiagramId
+  const children = new Map()
+  for (const [slug, d] of diagrams) {
+    const kids = new Set()
+    for (const n of d.nodes ?? []) {
+      if (isStr(n?.subDiagramId)) kids.add(n.subDiagramId)
+    }
+    children.set(slug, kids)
+  }
+
+  const WHITE = 0,
+    GRAY = 1,
+    BLACK = 2
+  const color = new Map([...children.keys()].map((s) => [s, WHITE]))
+
+  const dfs = (s, stack) => {
+    color.set(s, GRAY)
+    stack.push(s)
+    for (const c of children.get(s) ?? []) {
+      if (!children.has(c)) continue // unknown child already reported
+      const col = color.get(c)
+      if (col === GRAY) {
+        const i = stack.indexOf(c)
+        const cycle = [...stack.slice(i), c].join(' → ')
+        report.err('architecture', `drill-down cycle detected via subDiagramId: ${cycle}`)
+      } else if (col === WHITE) {
+        dfs(c, stack)
+      }
+    }
+    stack.pop()
+    color.set(s, BLACK)
+  }
+  for (const s of children.keys()) if (color.get(s) === WHITE) dfs(s, [])
+}
+
+async function main() {
+  const root = resolve(process.argv[2] ?? 'architecture')
+  const report = new Report()
+
+  if (!(await exists(root))) {
+    console.error(`[error] architecture directory not found: ${root}`)
+    process.exit(2)
+  }
+
+  const manifestPath = join(root, 'manifest.json')
+  if (!(await exists(manifestPath))) {
+    console.error(`[error] missing ${manifestPath}`)
+    process.exit(1)
+  }
+
+  let manifest
+  try {
+    manifest = await loadJson(manifestPath)
+  } catch (e) {
+    console.error(`[error] ${e.message}`)
+    process.exit(1)
+  }
+
+  validateManifest(manifest, report)
+
+  const diagramsDir = join(root, 'diagrams')
+  const descriptionsDir = join(root, 'descriptions')
+
+  if (!(await exists(diagramsDir))) {
+    report.err('architecture', `missing diagrams/ directory`)
+    report.print()
+    process.exit(1)
+  }
+
+  const onDisk = (await readdir(diagramsDir)).filter((f) => extname(f) === '.json').map((f) => basename(f, '.json'))
+  const onDiskSet = new Set(onDisk)
+
+  const listed = new Set(Array.isArray(manifest.diagrams) ? manifest.diagrams : [])
+  for (const slug of listed) {
+    if (!onDiskSet.has(slug))
+      report.err('architecture', `manifest lists "${slug}" but diagrams/${slug}.json does not exist`)
+  }
+  for (const slug of onDisk) {
+    if (!listed.has(slug))
+      report.warn('architecture', `diagrams/${slug}.json exists but is not listed in manifest.diagrams`)
+  }
+
+  const descriptionsAvailable = new Set()
+  if (await exists(descriptionsDir)) {
+    for (const f of await readdir(descriptionsDir)) {
+      if (extname(f) === '.md') descriptionsAvailable.add(basename(f, '.md'))
+    }
+  } else {
+    report.warn('architecture', `descriptions/ directory does not exist`)
+  }
+
+  const diagrams = new Map()
+  for (const slug of onDisk) {
+    try {
+      const d = await loadJson(join(diagramsDir, `${slug}.json`))
+      if (validateDiagramShape(slug, d, report)) diagrams.set(slug, d)
+    } catch (e) {
+      report.err(`diagrams/${slug}.json`, e.message)
+    }
+  }
+
+  const allSlugs = new Set(diagrams.keys())
+  const allNodeIds = new Map()
+  for (const [slug, d] of diagrams) {
+    validateDiagramReferences(slug, d, report, allSlugs, descriptionsAvailable, allNodeIds)
+  }
+
+  // Warn about orphan description files
+  const usedDescriptionIds = new Set(allNodeIds.keys())
+  for (const id of descriptionsAvailable) {
+    if (!usedDescriptionIds.has(id)) {
+      report.warn('architecture', `descriptions/${id}.md has no matching node id`)
+    }
+  }
+
+  detectDrillDownCycles(diagrams, report)
+
+  report.print()
+  process.exit(report.ok ? 0 : 1)
+}
+
+main().catch((e) => {
+  console.error(`[internal error] ${e.stack || e.message}`)
+  process.exit(2)
+})


### PR DESCRIPTION
## Summary
- Adds `tecture` under `(architecture)` — a portable file-based architecture skill that authors and maintains `./architecture/` (manifest + per-diagram JSON + per-node markdown) grounded in the repo's real tech stack, deployables, and external dependencies.
- Ships a dependency-free Node validator (`scripts/validate.mjs`) with JSON Schema validation, reference integrity, cycle detection, and global node-id uniqueness.
- Minimal working example (15-node e-commerce architecture) + JSON Schemas under `references/`.

## Cross-skill scope
The `Do NOT use for` clause explicitly excludes: editing via the Tecture MCP server (use it directly), one-off inline mermaid diagrams, and non-structural docs like deployment runbooks or API specs. No overlap with sibling `(architecture)` skills — those focus on decomposition, domain analysis, coupling, and modular principles; `tecture` is the authoring/maintenance skill for the file-based artifact itself.

## Test plan
- [x] `npm run validate` — 25 checks passed, 0 warnings
- [x] `npm run lint` — no new errors (`.mjs` script uses `/* global console, process */` for flat-config compatibility)
- [x] `npm run format` — applied
- [x] Local smoke test — validator exits 0 against the bundled example
- [ ] Snyk scan — fork PRs skip CI secrets per CONTRIBUTING.md; maintainers can run via merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)