### PR TITLE
Add Skills宝 as a Chinese browse/install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ A glimpse of what's available in our growing catalog:
   <a href="#-quick-start"><strong>→ Browse all skills</strong></a>
 </p>
 
+<p align="center">
+  Chinese users can also browse and install skills through <a href="https://skilery.com" target="_blank">Skills宝</a>.
+</p>
+
 ## 🚀 Quick Start
 
 ### Install Skills in Your Project


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to search and install agent skills directly. This fits the repository browse/install focus and gives Chinese users a faster entry point to the existing skills marketplace.