### PR TITLE
feat(cli): support configuring default target agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Each step shows a **← Back** option to return and revise your choices.
 
 > **Note**: You can use either `npx @tech-leads-club/agent-skills` or install globally and use `agent-skills` directly.
 
+→ We recommend you to use the `agents` command to setup the target agents before starting to install the skills.
+
 ```bash
 # Interactive mode (default)
 npx @tech-leads-club/agent-skills
@@ -143,16 +145,34 @@ npx @tech-leads-club/agent-skills
 agent-skills list
 agent-skills ls        # Alias
 
+# Auto-detect installed agents and set them as target (uses the home directory for detection)
+agent-skills agents --auto
+
+# Add agents to target list
+agent-skills agents --add cursor
+
+# Set entire target agents list
+agent-skills agents --set cursor claude-code
+
+# Remove agents from target list
+agent-skills agents --remove claude-code
+
+# Show current target agents list
+agent-skills agents --show
+
+# Clear target agents list
+agent-skills agents --clear
+
 # Install one skill
 agent-skills install -s tlc-spec-driven
 
 # Install multiple skills at once
 agent-skills install -s aws-advisor coding-guidelines docs-writer
 
-# Install to specific agents
+# Install to specific agents (override global target agents)
 agent-skills install -s my-skill -a cursor claude-code
 
-# Install multiple skills to multiple agents
+# Install multiple skills to multiple agents (override global target agents)
 agent-skills install -s aws-advisor nx-workspace -a cursor windsurf cline
 
 # Install globally (to ~/.gemini, ~/.claude, etc.)

--- a/packages/cli/src/cli/__tests__/agents.test.ts
+++ b/packages/cli/src/cli/__tests__/agents.test.ts
@@ -1,0 +1,206 @@
+import { jest } from '@jest/globals'
+import type { AgentType } from '@tech-leads-club/core'
+
+const mockDetectInstalledAgents = jest.fn<() => AgentType[]>()
+jest.unstable_mockModule('@tech-leads-club/core', () => ({
+  AGENT_TYPES: ['cursor', 'github-copilot', 'cline'] as AgentType[],
+  detectInstalledAgents: mockDetectInstalledAgents,
+}))
+
+const mockLoadConfig = jest.fn<() => Promise<{ targetAgents: AgentType[] }>>()
+const mockSaveConfig = jest.fn<(config: { targetAgents: AgentType[] }) => Promise<void>>()
+jest.unstable_mockModule('../../services/config', () => ({
+  loadConfig: mockLoadConfig,
+  saveConfig: mockSaveConfig,
+}))
+
+jest.unstable_mockModule('../../ports', () => ({
+  ports: {},
+}))
+
+jest.unstable_mockModule('chalk', () => ({
+  default: {
+    red: (s: string) => s,
+    green: (s: string) => s,
+    yellow: (s: string) => s,
+    dim: (s: string) => s,
+    bold: (s: string) => s,
+    blue: (s: string) => s,
+  },
+}))
+
+const { runCliAgents } = await import('../agents')
+
+describe('runCliAgents CLI', () => {
+  let mockExit: jest.SpiedFunction<typeof process.exit>
+  let mockConsoleLog: jest.SpiedFunction<typeof console.log>
+  let mockConsoleError: jest.SpiedFunction<typeof console.error>
+  let mockConsoleWarn: jest.SpiedFunction<typeof console.warn>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit: ${code}`)
+    })
+
+    mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+    mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor'] })
+  })
+
+  afterAll(() => {
+    mockExit.mockRestore()
+    mockConsoleLog.mockRestore()
+    mockConsoleError.mockRestore()
+    mockConsoleWarn.mockRestore()
+  })
+
+  describe('Validation', () => {
+    it('should throw an error and exit if multiple options are provided (conflicting flags)', async () => {
+      await expect(runCliAgents({ add: ['cursor'], set: ['cline'] })).rejects.toThrow('process.exit: 1')
+
+      expect(mockConsoleError).toHaveBeenCalledWith('❌ Only one option can be used at a time')
+      expect(mockLoadConfig).not.toHaveBeenCalled()
+    })
+
+    it('should throw an error and exit if unknown agents are provided', async () => {
+      await expect(runCliAgents({ add: ['unknown-agent'] })).rejects.toThrow('process.exit: 1')
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌ Unknown agent(s): unknown-agent'))
+      expect(mockSaveConfig).not.toHaveBeenCalled()
+    })
+
+    it('should throw an error and exit if a mix of valid and invalid agents are provided', async () => {
+      await expect(runCliAgents({ add: ['cursor', 'invalid-agent'] })).rejects.toThrow('process.exit: 1')
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('❌ Unknown agent(s): invalid-agent'))
+      expect(mockSaveConfig).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Options', () => {
+    it('should handle --add and append to existing config', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor'] })
+
+      await runCliAgents({ add: ['cline'] })
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({ targetAgents: ['cursor', 'cline'] })
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ Target agents updated with: cline'))
+    })
+
+    it('should handle --add without duplicating agents', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor'] })
+
+      await runCliAgents({ add: ['cursor', 'cline'] })
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({ targetAgents: ['cursor', 'cline'] })
+    })
+
+    it('should handle flags passed with empty arrays without modifying the config', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor'] })
+
+      await runCliAgents({ add: [] })
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({ targetAgents: ['cursor'] })
+    })
+
+    it('should handle --set and overwrite existing config', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor'] })
+
+      await runCliAgents({ set: ['github-copilot'] })
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({ targetAgents: ['github-copilot'] })
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ Target agents set to: github-copilot'))
+    })
+
+    it('should handle --remove and filter existing config', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor', 'cline'] })
+
+      await runCliAgents({ remove: ['cursor'] })
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({ targetAgents: ['cline'] })
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('✅ Target agents removed: cursor'))
+    })
+
+    it('should skip saving and warn if the removed agent is not in the current config', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cline'] })
+
+      await runCliAgents({ remove: ['cursor'] })
+
+      expect(mockSaveConfig).not.toHaveBeenCalled()
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('⚠️  None of the specified agents were in your target list.'),
+      )
+    })
+
+    it('should handle --clear and empty config', async () => {
+      await runCliAgents({ clear: true })
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({ targetAgents: [] })
+      expect(mockConsoleLog).toHaveBeenCalledWith('🧹 Target agents cleared')
+    })
+
+    it('should handle --show when config has agents', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor', 'cline'] })
+
+      await runCliAgents({ show: true })
+
+      expect(mockConsoleLog).toHaveBeenCalledWith('Target agents:')
+      expect(mockConsoleLog).toHaveBeenCalledWith('  cursor, cline')
+    })
+
+    it('should handle --show when config is empty', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: [] })
+
+      await runCliAgents({ show: true })
+
+      expect(mockConsoleLog).toHaveBeenCalledWith('  (None set)')
+    })
+  })
+
+  describe('--auto detection', () => {
+    it('should detect agents and save them successfully', async () => {
+      mockDetectInstalledAgents.mockReturnValue(['cursor', 'cline'])
+
+      await runCliAgents({ auto: true })
+
+      expect(mockSaveConfig).toHaveBeenCalledWith({ targetAgents: ['cursor', 'cline'] })
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('✅ Auto-detected and set target agents: cursor, cline'),
+      )
+    })
+
+    it('should log a WARNING and exit if detection is empty BUT current config exists', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: ['cursor'] })
+      mockDetectInstalledAgents.mockReturnValue([])
+
+      await expect(runCliAgents({ auto: true })).rejects.toThrow('process.exit: 1')
+
+      expect(mockConsoleWarn).toHaveBeenCalledWith('⚠️  No supported agents detected. Keeping existing configuration.')
+      expect(mockSaveConfig).not.toHaveBeenCalled()
+    })
+
+    it('should log an ERROR and exit if detection is empty AND current config is empty', async () => {
+      mockLoadConfig.mockResolvedValue({ targetAgents: [] })
+      mockDetectInstalledAgents.mockReturnValue([])
+
+      await expect(runCliAgents({ auto: true })).rejects.toThrow('process.exit: 1')
+
+      expect(mockConsoleError).toHaveBeenCalledWith('❌ No supported agents detected.')
+      expect(mockSaveConfig).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Default Behavior', () => {
+    it('should print the help menu when no valid options are provided', async () => {
+      await runCliAgents({})
+
+      expect(mockConsoleLog).toHaveBeenCalledWith('Target agents management')
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Options:'))
+      expect(mockSaveConfig).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/cli/src/cli/agents.ts
+++ b/packages/cli/src/cli/agents.ts
@@ -1,0 +1,153 @@
+import type { AgentType } from '@tech-leads-club/core'
+import { AGENT_TYPES, detectInstalledAgents } from '@tech-leads-club/core'
+import chalk from 'chalk'
+
+import { ports } from '../ports'
+import { loadConfig, saveConfig } from '../services/config'
+
+interface AgentsCliOptions {
+  add?: string[]
+  set?: string[]
+  remove?: string[]
+  clear?: boolean
+  show?: boolean
+  auto?: boolean
+}
+
+function validateOptions(options: AgentsCliOptions): void {
+  const activeOptionsCount = [
+    options.add,
+    options.set,
+    options.remove,
+    options.show,
+    options.clear,
+    options.auto,
+  ].filter(Boolean).length
+
+  if (activeOptionsCount > 1) {
+    console.error(chalk.red('❌ Only one option can be used at a time'))
+    process.exit(1)
+  }
+}
+
+async function autoDetectAgents(currentAgents: AgentType[]): Promise<void> {
+  const detected = detectInstalledAgents(ports)
+
+  if (detected.length === 0) {
+    if (currentAgents.length > 0) {
+      console.warn(chalk.yellow('⚠️  No supported agents detected. Keeping existing configuration.'))
+    } else {
+      console.error(chalk.red('❌ No supported agents detected.'))
+    }
+    process.exit(1)
+  }
+
+  await saveConfig({ targetAgents: detected })
+  console.log(chalk.green(`✅ Auto-detected and set target agents: ${detected.join(', ')}`))
+}
+
+function validateAgents(agents: string[]): AgentType[] {
+  const invalidAgents = agents.filter((a) => !AGENT_TYPES.includes(a as AgentType))
+  if (invalidAgents.length > 0) {
+    console.error(chalk.red(`❌ Unknown agent(s): ${invalidAgents.join(', ')}`))
+    console.error(chalk.dim(`   Valid agents: ${AGENT_TYPES.join(', ')}`))
+    process.exit(1)
+  }
+  return agents as AgentType[]
+}
+
+async function addAgents(rawAgents: string[], currentAgents: AgentType[]): Promise<void> {
+  const validAgents = validateAgents(rawAgents)
+  const newAgents = Array.from(new Set([...currentAgents, ...validAgents])) as AgentType[]
+  await saveConfig({ targetAgents: newAgents })
+  console.log(chalk.green(`✅ Target agents updated with: ${validAgents.join(', ')}`))
+}
+
+async function setAgents(rawAgents: string[]): Promise<void> {
+  const validAgents = validateAgents(rawAgents)
+  await saveConfig({ targetAgents: validAgents })
+  console.log(chalk.green(`✅ Target agents set to: ${validAgents.join(', ')}`))
+}
+
+async function removeAgents(rawAgents: string[], currentAgents: AgentType[]): Promise<void> {
+  const validAgents = validateAgents(rawAgents)
+
+  const removedAgents = currentAgents.filter((a) => validAgents.includes(a))
+  if (removedAgents.length === 0) {
+    console.warn(chalk.yellow('⚠️  None of the specified agents were in your target list.'))
+    console.log(chalk.dim(`   Current target agents: ${currentAgents.join(', ')}`))
+    return
+  }
+
+  const newAgents = currentAgents.filter((a) => !removedAgents.includes(a))
+
+  await saveConfig({ targetAgents: newAgents })
+  console.log(chalk.green(`✅ Target agents removed: ${removedAgents.join(', ')}`))
+}
+
+async function showAgents(currentAgents: AgentType[]): Promise<void> {
+  console.log(chalk.bold('Target agents:'))
+  if (currentAgents.length > 0) {
+    console.log(`  ${currentAgents.join(', ')}`)
+  } else {
+    console.log(chalk.dim('  (None set)'))
+  }
+}
+
+async function clearAgents(): Promise<void> {
+  await saveConfig({ targetAgents: [] })
+  console.log(chalk.green('🧹 Target agents cleared'))
+}
+
+export async function runCliAgents(options: AgentsCliOptions): Promise<void> {
+  validateOptions(options)
+
+  const config = await loadConfig()
+  const currentAgents = config.targetAgents || []
+
+  if (options.auto) {
+    await autoDetectAgents(currentAgents)
+  }
+
+  if (options.add) {
+    await addAgents(options.add, currentAgents)
+    return
+  }
+
+  if (options.set) {
+    await setAgents(options.set)
+    return
+  }
+
+  if (options.remove) {
+    await removeAgents(options.remove, currentAgents)
+    return
+  }
+
+  if (options.show) {
+    await showAgents(currentAgents)
+    return
+  }
+
+  if (options.clear) {
+    await clearAgents()
+    return
+  }
+
+  console.log(chalk.bold('Target agents management'))
+  console.log(chalk.dim('Manage the agents that will receive the skills by default when you install them.'))
+  console.log(chalk.dim('Let this configuration empty to auto-detect the agents you have installed.'))
+  console.log(chalk.dim('You can override this configuration when you install a skill by using the --agent flag.'))
+  console.log()
+  console.log(
+    'Usage: agent-skills agents [--add <agents...>] [--set <agents...>] [--remove <agents...>] [--show] [--clear] [--auto]',
+  )
+  console.log()
+  console.log('Options:')
+  console.log(`  ${chalk.blue('--add')}           Add agents to target list`)
+  console.log(`  ${chalk.blue('--set')}           Set entire target agents list`)
+  console.log(`  ${chalk.blue('--remove')}        Remove agents from target list`)
+  console.log(`  ${chalk.blue('--show')}          Show current target agents list`)
+  console.log(`  ${chalk.blue('--clear')}         Clear target agents list`)
+  console.log(`  ${chalk.blue('--auto')}          Auto-detect installed agents and set them as target`)
+}

--- a/packages/cli/src/cli/install.ts
+++ b/packages/cli/src/cli/install.ts
@@ -1,8 +1,16 @@
-import chalk from 'chalk'
-import { AGENT_TYPES, ensureSkillDownloaded, forceDownloadSkill, getRemoteSkills, installSkills } from '@tech-leads-club/core'
 import type { AgentType, InstallOptions, SkillInfo } from '@tech-leads-club/core'
+import {
+  AGENT_TYPES,
+  detectInstalledAgents,
+  ensureSkillDownloaded,
+  forceDownloadSkill,
+  getRemoteSkills,
+  installSkills,
+} from '@tech-leads-club/core'
+import chalk from 'chalk'
 
 import { ports } from '../ports'
+import { loadConfig } from '../services/config'
 
 interface InstallCliOptions {
   skill?: string[]
@@ -23,7 +31,9 @@ async function downloadSkills(skillNames: string[], forceDownload: boolean): Pro
       continue
     }
 
-    const path = forceDownload ? await forceDownloadSkill(ports, skillName) : await ensureSkillDownloaded(ports, skillName)
+    const path = forceDownload
+      ? await forceDownloadSkill(ports, skillName)
+      : await ensureSkillDownloaded(ports, skillName)
     if (path) {
       selectedSkills.push({ ...skill, path })
     } else {
@@ -32,6 +42,25 @@ async function downloadSkills(skillNames: string[], forceDownload: boolean): Pro
   }
 
   return selectedSkills
+}
+
+async function getTargetAgents(options: InstallCliOptions): Promise<{ agents: AgentType[]; source: string }> {
+  if (options.agent && options.agent.length > 0) {
+    return { agents: options.agent as AgentType[], source: 'CLI flag' }
+  }
+
+  const config = await loadConfig()
+  const userAgents = config.targetAgents
+  if (userAgents && userAgents.length > 0) {
+    return { agents: userAgents, source: 'user configuration' }
+  }
+
+  const detectedAgents = detectInstalledAgents(ports)
+  if (detectedAgents.length > 0) {
+    return { agents: detectedAgents, source: 'auto-detection' }
+  }
+
+  return { agents: [], source: '' }
 }
 
 function showInstallResults(results: Awaited<ReturnType<typeof installSkills>>): void {
@@ -72,14 +101,27 @@ export async function runCliInstall(options: InstallCliOptions): Promise<void> {
     process.exit(1)
   }
 
-  const rawAgents = options.agent || ['cursor', 'claude-code', 'windsurf']
-  const invalidAgents = rawAgents.filter((a) => !AGENT_TYPES.includes(a as AgentType))
+  const { agents: targetAgents, source } = await getTargetAgents(options)
+  if (targetAgents.length === 0) {
+    console.error(chalk.red('❌ No agents specified and none could be detected or found in configuration.'))
+    console.error(
+      chalk.dim(
+        'You can use the "--agent" flag in the "agent-skills install" command to specify the target agents for this installation.',
+      ),
+    )
+    console.error(chalk.dim('You can also use the "agent-skills agents" command to manage the target agents globally.'))
+    process.exit(1)
+  }
+
+  console.log(chalk.blue(`⏳ Using ${source} to identify target agents: ${targetAgents.join(', ')}`))
+
+  const invalidAgents = targetAgents.filter((a) => !AGENT_TYPES.includes(a as AgentType))
   if (invalidAgents.length > 0) {
     console.error(chalk.red(`❌ Unknown agent(s): ${invalidAgents.join(', ')}`))
     console.error(chalk.dim(`   Valid agents: ${AGENT_TYPES.join(', ')}`))
     process.exit(1)
   }
-  const agents = rawAgents as AgentType[]
+  const agents = targetAgents as AgentType[]
   const method = options.symlink ? 'symlink' : 'copy'
 
   console.log(chalk.blue(`⏳ Installing ${skills.length} skill(s) to ${agents.length} agent(s)...`))

--- a/packages/cli/src/hooks/__tests__/useConfig.test.ts
+++ b/packages/cli/src/hooks/__tests__/useConfig.test.ts
@@ -4,6 +4,9 @@
 import { jest } from '@jest/globals'
 import { act, renderHook, waitFor } from '@testing-library/react'
 
+const actualFs = await import('node:fs/promises')
+const actualOs = await import('node:os')
+
 const mockMkdir = jest.fn<() => Promise<void>>()
 const mockReadFile = jest.fn<(path: string, encoding: string) => Promise<string>>()
 const mockWriteFile = jest.fn<(path: string, data: string, encoding: string) => Promise<void>>()
@@ -12,6 +15,7 @@ const mockRename = jest.fn<(oldPath: string, newPath: string) => Promise<void>>(
 const mockRm = jest.fn<(path: string, options?: { force?: boolean }) => Promise<void>>()
 
 jest.unstable_mockModule('node:fs/promises', () => ({
+  ...actualFs,
   mkdir: mockMkdir,
   readFile: mockReadFile,
   writeFile: mockWriteFile,
@@ -19,7 +23,7 @@ jest.unstable_mockModule('node:fs/promises', () => ({
   rm: mockRm,
 }))
 
-jest.unstable_mockModule('node:os', () => ({ homedir: mockHomedir }))
+jest.unstable_mockModule('node:os', () => ({ ...actualOs, homedir: mockHomedir }))
 
 const { useConfig } = await import('../useConfig')
 
@@ -33,7 +37,7 @@ describe('useConfig hook', () => {
 
   describe('initial load', () => {
     it('should load config on mount', async () => {
-      const config = { firstLaunchComplete: true, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const config = { firstLaunchComplete: true, shortcutsOverlayDismissed: false, version: '1.0.0', targetAgents: [] }
       mockReadFile.mockResolvedValue(JSON.stringify(config))
       const { result } = renderHook(() => useConfig())
       expect(result.current.loading).toBe(true)
@@ -47,7 +51,12 @@ describe('useConfig hook', () => {
     })
 
     it('should handle first launch state', async () => {
-      const config = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const config = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       mockReadFile.mockResolvedValue(JSON.stringify(config))
       const { result } = renderHook(() => useConfig())
       await waitFor(() => {
@@ -58,7 +67,7 @@ describe('useConfig hook', () => {
     })
 
     it('should handle shortcuts dismissed state', async () => {
-      const config = { firstLaunchComplete: true, shortcutsOverlayDismissed: true, version: '1.0.0' }
+      const config = { firstLaunchComplete: true, shortcutsOverlayDismissed: true, version: '1.0.0', targetAgents: [] }
       mockReadFile.mockResolvedValue(JSON.stringify(config))
       const { result } = renderHook(() => useConfig())
       await waitFor(() => {
@@ -78,6 +87,7 @@ describe('useConfig hook', () => {
         firstLaunchComplete: false,
         shortcutsOverlayDismissed: false,
         version: '1.0.0',
+        targetAgents: [],
       })
     })
 
@@ -91,6 +101,7 @@ describe('useConfig hook', () => {
         firstLaunchComplete: false,
         shortcutsOverlayDismissed: false,
         version: '1.0.0',
+        targetAgents: [],
       })
       expect(result.current.isFirstLaunch).toBe(true)
     })
@@ -98,7 +109,12 @@ describe('useConfig hook', () => {
 
   describe('markFirstLaunchComplete', () => {
     it('should update first launch state', async () => {
-      const initialConfig = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const initialConfig = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       const updatedConfig = { ...initialConfig, firstLaunchComplete: true }
       mockReadFile
         .mockResolvedValueOnce(JSON.stringify(initialConfig))
@@ -123,7 +139,12 @@ describe('useConfig hook', () => {
     })
 
     it('should handle errors when marking first launch complete', async () => {
-      const config = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const config = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       mockReadFile.mockResolvedValue(JSON.stringify(config))
       mockMkdir.mockResolvedValue(undefined)
       mockWriteFile.mockRejectedValue(new Error('Write failed'))
@@ -140,7 +161,12 @@ describe('useConfig hook', () => {
 
   describe('markShortcutsDismissed', () => {
     it('should update shortcuts dismissed state', async () => {
-      const initialConfig = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const initialConfig = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       const updatedConfig = { ...initialConfig, shortcutsOverlayDismissed: true }
       mockReadFile
         .mockResolvedValueOnce(JSON.stringify(initialConfig))
@@ -165,7 +191,12 @@ describe('useConfig hook', () => {
     })
 
     it('should handle errors when marking shortcuts dismissed', async () => {
-      const config = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const config = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       mockReadFile.mockResolvedValue(JSON.stringify(config))
       mockMkdir.mockResolvedValue(undefined)
       mockWriteFile.mockRejectedValue(new Error('Write failed'))
@@ -182,7 +213,12 @@ describe('useConfig hook', () => {
 
   describe('updateConfig', () => {
     it('should update config with partial updates', async () => {
-      const initialConfig = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const initialConfig = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       const updatedConfig = { ...initialConfig, firstLaunchComplete: true, shortcutsOverlayDismissed: true }
       mockReadFile
         .mockResolvedValueOnce(JSON.stringify(initialConfig))
@@ -207,7 +243,12 @@ describe('useConfig hook', () => {
     })
 
     it('should handle errors when updating config', async () => {
-      const config = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const config = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       mockReadFile.mockResolvedValue(JSON.stringify(config))
       mockMkdir.mockResolvedValue(undefined)
       mockWriteFile.mockRejectedValue(new Error('Write failed'))
@@ -224,7 +265,12 @@ describe('useConfig hook', () => {
 
   describe('cleanup', () => {
     it('should not update state after unmount', async () => {
-      const config = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const config = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       mockReadFile.mockImplementation(
         () =>
           new Promise((resolve) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -95,6 +95,21 @@ program
     runCliCache(options)
   })
 
+// Agents command
+program
+  .command('agents')
+  .description('Manage target agents')
+  .option('--auto', 'Auto-detect installed agents and set as target agents')
+  .option('--add <agents...>', 'Add agents to target list')
+  .option('--set <agents...>', 'Set entire target agents list')
+  .option('--remove <agents...>', 'Remove agents from target list')
+  .option('--show', 'Show current target agents list')
+  .option('--clear', 'Clear target agents list')
+  .action(async (options) => {
+    const { runCliAgents } = await import('./cli/agents')
+    await runCliAgents(options)
+  })
+
 // Credits command
 program
   .command('credits')

--- a/packages/cli/src/services/__tests__/config.test.ts
+++ b/packages/cli/src/services/__tests__/config.test.ts
@@ -1,6 +1,9 @@
 import { jest } from '@jest/globals'
 import { join } from 'node:path'
 
+const actualFs = await import('node:fs/promises')
+const actualOs = await import('node:os')
+
 const mockMkdir = jest.fn<() => Promise<void>>()
 const mockReadFile = jest.fn<(path: string, encoding: string) => Promise<string>>()
 const mockWriteFile = jest.fn<(path: string, data: string, encoding: string) => Promise<void>>()
@@ -10,6 +13,7 @@ const mockRename = jest.fn<(oldPath: string, newPath: string) => Promise<void>>(
 const mockRm = jest.fn<(path: string, options?: { force?: boolean }) => Promise<void>>()
 
 jest.unstable_mockModule('node:fs/promises', () => ({
+  ...actualFs,
   mkdir: mockMkdir,
   readFile: mockReadFile,
   writeFile: mockWriteFile,
@@ -18,6 +22,7 @@ jest.unstable_mockModule('node:fs/promises', () => ({
 }))
 
 jest.unstable_mockModule('node:os', () => ({
+  ...actualOs,
   homedir: mockHomedir,
 }))
 
@@ -43,11 +48,21 @@ describe('config service', () => {
     it('should return default config when file does not exist', async () => {
       mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'))
       const config = await loadConfig()
-      expect(config).toEqual({ firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' })
+      expect(config).toEqual({
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      })
     })
 
     it('should load and validate existing config', async () => {
-      const existingConfig = { firstLaunchComplete: true, shortcutsOverlayDismissed: true, version: '1.0.0' }
+      const existingConfig = {
+        firstLaunchComplete: true,
+        shortcutsOverlayDismissed: true,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       mockReadFile.mockResolvedValue(JSON.stringify(existingConfig))
       const config = await loadConfig()
       expect(mockReadFile).toHaveBeenCalledWith(expectedConfigPath, 'utf-8')
@@ -58,25 +73,73 @@ describe('config service', () => {
       const partialConfig = { firstLaunchComplete: true }
       mockReadFile.mockResolvedValue(JSON.stringify(partialConfig))
       const config = await loadConfig()
-      expect(config).toEqual({ firstLaunchComplete: true, shortcutsOverlayDismissed: false, version: '1.0.0' })
+      expect(config).toEqual({
+        firstLaunchComplete: true,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      })
     })
 
     it('should return defaults when config is invalid JSON', async () => {
       mockReadFile.mockResolvedValue('invalid json{')
       const config = await loadConfig()
-      expect(config).toEqual({ firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' })
+      expect(config).toEqual({
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      })
     })
 
     it('should return defaults when config is not an object', async () => {
       mockReadFile.mockResolvedValue(JSON.stringify('string value'))
       const config = await loadConfig()
-      expect(config).toEqual({ firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' })
+      expect(config).toEqual({
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      })
+    })
+
+    it('should filter out invalid target agents', async () => {
+      const existingConfig = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: ['invalid', 'cursor'],
+      }
+      mockReadFile.mockResolvedValue(JSON.stringify(existingConfig))
+      const config = await loadConfig()
+      expect(config).toEqual({
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: ['cursor'],
+      })
+    })
+
+    it('should return defaults when targetAgents is not an array', async () => {
+      mockReadFile.mockResolvedValue(JSON.stringify({ targetAgents: 'string value' }))
+      const config = await loadConfig()
+      expect(config).toEqual({
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      })
     })
   })
 
   describe('saveConfig', () => {
     it('should create directory, save config to temp file, and rename', async () => {
-      const existingConfig = { firstLaunchComplete: false, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const existingConfig = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      }
       mockReadFile.mockResolvedValue(JSON.stringify(existingConfig))
       mockMkdir.mockResolvedValue(undefined)
       mockWriteFile.mockResolvedValue(undefined)
@@ -88,12 +151,22 @@ describe('config service', () => {
       const writeCall = mockWriteFile.mock.calls[0] as [string, string, string]
       expect(writeCall[0]).toBe(`${expectedConfigPath}.tmp`)
       const savedConfig = JSON.parse(writeCall[1])
-      expect(savedConfig).toEqual({ firstLaunchComplete: true, shortcutsOverlayDismissed: false, version: '1.0.0' })
+      expect(savedConfig).toEqual({
+        firstLaunchComplete: true,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: [],
+      })
       expect(mockRename).toHaveBeenCalledWith(`${expectedConfigPath}.tmp`, expectedConfigPath)
     })
 
     it('should merge partial updates with existing config', async () => {
-      const existingConfig = { firstLaunchComplete: true, shortcutsOverlayDismissed: false, version: '1.0.0' }
+      const existingConfig = {
+        firstLaunchComplete: true,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: ['cursor'],
+      }
       mockReadFile.mockResolvedValue(JSON.stringify(existingConfig))
       mockMkdir.mockResolvedValue(undefined)
       mockWriteFile.mockResolvedValue(undefined)
@@ -103,7 +176,50 @@ describe('config service', () => {
       const writeCall = mockWriteFile.mock.calls[0] as [string, string, string]
 
       const savedConfig = JSON.parse(writeCall[1])
-      expect(savedConfig).toEqual({ firstLaunchComplete: true, shortcutsOverlayDismissed: true, version: '1.0.0' })
+      expect(savedConfig).toEqual({
+        firstLaunchComplete: true,
+        shortcutsOverlayDismissed: true,
+        version: '1.0.0',
+        targetAgents: ['cursor'],
+      })
+      expect(mockRename).toHaveBeenCalledWith(`${expectedConfigPath}.tmp`, expectedConfigPath)
+    })
+  })
+
+  describe('targetAgents handling', () => {
+    it('should load targetAgents when provided in file', async () => {
+      const existingConfig = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: ['cursor'],
+      }
+      mockReadFile.mockResolvedValue(JSON.stringify(existingConfig))
+      const config = await loadConfig()
+      expect(config).toEqual(existingConfig)
+    })
+
+    it('should save targetAgents when provided in config', async () => {
+      const existingConfig = {
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: ['cursor'],
+      }
+      mockReadFile.mockResolvedValue(JSON.stringify(existingConfig))
+      mockMkdir.mockResolvedValue(undefined)
+      mockWriteFile.mockResolvedValue(undefined)
+      mockRename.mockResolvedValue(undefined)
+      await saveConfig({ targetAgents: ['github-copilot', 'cursor'] })
+      expect(mockWriteFile).toHaveBeenCalledTimes(1)
+      const writeCall = mockWriteFile.mock.calls[0] as [string, string, string]
+      const savedConfig = JSON.parse(writeCall[1])
+      expect(savedConfig).toEqual({
+        firstLaunchComplete: false,
+        shortcutsOverlayDismissed: false,
+        version: '1.0.0',
+        targetAgents: ['github-copilot', 'cursor'],
+      })
       expect(mockRename).toHaveBeenCalledWith(`${expectedConfigPath}.tmp`, expectedConfigPath)
     })
   })

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -2,22 +2,31 @@ import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
+import { AGENT_TYPES, type AgentType } from '@tech-leads-club/core'
+
 import { CONFIG_DIR, CONFIG_FILE, CURRENT_CONFIG_VERSION } from '../utils/constants'
 
 export interface UserConfig {
   firstLaunchComplete: boolean
   shortcutsOverlayDismissed: boolean
   version: string
+  targetAgents: AgentType[]
 }
 
 const DEFAULT_CONFIG: UserConfig = {
   firstLaunchComplete: false,
   shortcutsOverlayDismissed: false,
   version: CURRENT_CONFIG_VERSION,
+  targetAgents: [],
 }
 
 function getConfigPath(): string {
   return join(homedir(), CONFIG_DIR, CONFIG_FILE)
+}
+
+function validateTargetAgents(agents: unknown): AgentType[] {
+  if (!Array.isArray(agents)) return []
+  return agents.filter((agent) => AGENT_TYPES.includes(agent))
 }
 
 function validateConfig(config: unknown): UserConfig {
@@ -28,6 +37,7 @@ function validateConfig(config: unknown): UserConfig {
     firstLaunchComplete: Boolean(partial.firstLaunchComplete),
     shortcutsOverlayDismissed: Boolean(partial.shortcutsOverlayDismissed),
     version: String(partial.version || CURRENT_CONFIG_VERSION),
+    targetAgents: validateTargetAgents(partial.targetAgents),
   }
 }
 


### PR DESCRIPTION
## Summary

This PR introduces a configuration-driven approach for managing target agents, allowing users to define which agents receive skills by default during installation. It includes a new CLI command for agent management and enhances the `install` command to support configurable defaults and automatic detection of installed agents.

## Context

Previously, the `install` command relied on hardcoded default agents. To provide a more flexible and user-friendly experience, we needed a way to:

1. Store a persistent list of target agents in the CLI configuration.
2. Provide CLI tools to manage this configuration (`add`, `set`, `show`, `clear`, `auto`).
3. Transition the `install` command to respect these user-defined preferences, falling back to auto-detection when no specific agents are set, while still allowing for CLI flag overrides.

## Modifications

- **Configuration Update:** Added `targetAgents` to the global CLI configuration schema and updated tests to reflect this change.
- **New CLI Command:** Implemented `agents` command in `packages/cli/src/cli/agents.ts` and registered it in `packages/cli/src/index.ts` to enable management of `targetAgents`.
- **Install Command Enhancement:** Refactored `packages/cli/src/cli/install.ts` to implement `getTargetAgents()`. This function now determines the target agents in the following order of precedence:
  1. CLI `--agent` flag.
  2. User-defined `targetAgents` configuration.
  3. Auto-detection of installed agents via the core library.
- **Updated CLI Feedback:** Improved user feedback in the `install` command to clearly indicate the source used for identifying target agents and to provide better error messages when no agents are found.
