### PR TITLE
fix: trim whitespace from search query in marketplace

### DIFF
--- a/packages/marketplace/src/app/skills/SkillsClient.tsx
+++ b/packages/marketplace/src/app/skills/SkillsClient.tsx
@@ -19,11 +19,12 @@ export function SkillsClient({ data }: SkillsClientProps) {
   const [currentPage, setCurrentPage] = useState(1)
 
   const filteredSkills = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase()
     return data.skills.filter((skill) => {
       const matchesSearch =
-        searchQuery === '' ||
-        skill.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        skill.description.toLowerCase().includes(searchQuery.toLowerCase())
+        normalizedQuery === '' ||
+        skill.name.toLowerCase().includes(normalizedQuery) ||
+        skill.description.toLowerCase().includes(normalizedQuery)
 
       const matchesCategory = selectedCategory === null || skill.category === selectedCategory
 


### PR DESCRIPTION
Fixes a bug where searching with trailing/leading whitespace (e.g., "react ") would not find skills matching the base term ("react").

The search query is now normalized with .trim() before matching against skill names and descriptions.