### PR TITLE
fix(security): bump vulnerable transitive runtime deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16248,9 +16248,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -17720,9 +17720,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -18592,9 +18592,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -29867,9 +29867,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -99,6 +99,10 @@
   "overrides": {
     "follow-redirects": "^1.16.0",
     "postcss": "^8.5.10",
+    "fast-uri": "^3.1.2",
+    "hono": "^4.12.18",
+    "ip-address": "^10.1.1",
+    "ws": "^8.20.1",
     "nx": {
       "brace-expansion": "^5.0.5",
       "yaml": "^2.8.3"


### PR DESCRIPTION
## Summary

Resolves **9 known advisories (2 HIGH, 6 MODERATE, 1 LOW)** in transitive production dependency chains of `@tech-leads-club/agent-skills-mcp` and the JSON-schema validator (`ajv → fast-uri`). Implemented as additions to the root `overrides` block so they coexist with the existing `follow-redirects` / `postcss` / `brace-expansion` pins.

## Findings

| Package | From → To | Pulled by | Severity | Advisories |
|---|---|---|---|---|
| `fast-uri` | 3.1.0 → 3.1.2 | `ajv` (schema validation) | 2 × **HIGH** | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal via percent-encoded `..`), [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion via percent-encoded authority delimiters) |
| `hono` | 4.12.15 → 4.12.19 | `fastmcp`, `@modelcontextprotocol/sdk` (MCP runtime) | 4 × MOD, 1 × LOW | [GHSA-9vqf-7f2p-gf9v](https://github.com/advisories/GHSA-9vqf-7f2p-gf9v) (`bodyLimit` bypass for chunked/unknown-length requests), [GHSA-p77w-8qqv-26rm](https://github.com/advisories/GHSA-p77w-8qqv-26rm) (cache middleware ignores `Vary: Authorization` / `Vary: Cookie` — cross-user cache leak), [GHSA-69xw-7hcm-h432](https://github.com/advisories/GHSA-69xw-7hcm-h432) (JSX HTML injection), [GHSA-qp7p-654g-cw7p](https://github.com/advisories/GHSA-qp7p-654g-cw7p) (CSS declaration injection via style object values), [GHSA-hm8q-7f3q-5f36](https://github.com/advisories/GHSA-hm8q-7f3q-5f36) (improper validation of NumericDate JWT claims) |
| `ip-address` | 10.1.0 → 10.2.0 | `express-rate-limit` (MCP runtime) | 1 × MOD | [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) (XSS in `Address6` HTML-emitting methods) |
| `ws` | 8.18.0 → 8.20.1 | `ink` (CLI TUI) | 1 × MOD | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (uninitialized memory disclosure) |

## Impact

- The MCP server (`@tech-leads-club/agent-skills-mcp`) ships `hono` and `express-rate-limit` as part of its `fastmcp` runtime dependency. The `bodyLimit` bypass and `Vary:` cache leak are exploitable against any process exposing the SSE/HTTP transport; the `ip-address` XSS is reachable wherever `Address6` output is rendered.
- `fast-uri`'s percent-encoded path / authority parsing is used by `ajv` for `uri`-format validation. Any consumer that validates user-supplied URIs against a schema can be bypassed.
- `ws` memory disclosure affects every server-side `ws` consumer; in this repo `ws` is pulled transitively by `ink` but it is still part of the published `@tech-leads-club/agent-skills` install graph, so downstream tooling that re-uses the resolved version inherits the issue.

## Location

`package.json` — root `overrides` block (lines 99–106 before this PR).
`package-lock.json` — only the four affected entries change; no other resolutions are touched.

## Fix

Four additional override entries; lockfile regenerated with `npm 11.14.1` so the diff stays limited to the four `version` / `resolved` / `integrity` triples (no churn in `libc` / hoisting metadata).

```json
"overrides": {
  "follow-redirects": "^1.16.0",
  "postcss": "^8.5.10",
  "fast-uri": "^3.1.2",
  "hono": "^4.12.18",
  "ip-address": "^10.1.1",
  "ws": "^8.20.1",
  "nx": {
    "brace-expansion": "^5.0.5",
    "yaml": "^2.8.3"
  }
}
```

All four bumps stay within the same major version, so semver compatibility with downstream consumers (`fastmcp`, `ajv`, `ink`, `express-rate-limit`) is preserved.

## Verification

- `osv-scanner --recursive .` post-fix: **0 findings** for the four targeted packages (down from 9 advisories before).
- `npm install --package-lock-only` clean; only the four packages move.
- Test suite was not executed locally — the monorepo declares `engines.node >=24` while the sandbox running this scan is on Node 22, so the existing CI is the right gate for the test run.

## Detected by

Aeon (vuln-scanner skill) + [osv-scanner](https://github.com/google/osv-scanner). Two purpose-built scanners (semgrep, trufflehog) ran cleanly against runtime code; the remaining osv findings are either dev-only (`nx` chain pulling vulnerable `axios` 1.15.0, `@babel/plugin-transform-modules-systemjs` 7.29.0, `webpack-dev-server` 5.2.3) or apply to the statically-exported marketplace (`next` 16.2.4 — `output: 'export'` in `next.config.mjs` makes the SSR/middleware/image-optimization advisories non-reachable in the GH Pages deployment). Happy to follow up with a separate PR for the dev-chain bumps if you'd like.

- Severity (highest in this PR): **HIGH** (fast-uri x2)
- 9 advisories total

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).