### PR TITLE
docs: use catalogue wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Install skills to any of these AI coding agents:
 
 ## 🌟 Featured Skills
 
-A glimpse of what's available in our growing catalog:
+A glimpse of what's available in our growing catalogue:
 
 | Skill                                                                                              | Category    | Description                                                                                                                                                                        |
 | -------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary\n- change 'catalog' to 'catalogue' in the README for wording consistency\n\n## Testing\n- not needed (documentation-only change)