### PR TITLE
docs: clarify MCP setup reference wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ rm -rf ~/.cache/agent-skills
 }
 ```
 
-→ Full setup for all clients (Cursor, Claude Code, VS Code, etc.), caching, and error reference: **[packages/mcp/README.md](packages/mcp/README.md)**
+→ Full setup for all clients (Cursor, Claude Code, VS Code, etc.), caching, and error-reference details: **[packages/mcp/README.md](packages/mcp/README.md)**
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Summary\n- improve the README sentence that links to the MCP setup guide\n- keep the meaning the same while making the wording a bit clearer\n\n## Testing\n- not needed (documentation-only change)