### PR TITLE
fix: correct OpenCode URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Install skills to any of these AI coding agents:
 |         **[Claude Code](https://claude.ai/code)**         |                    **[Aider](https://aider.chat)**                     |   **[Amazon Q](https://aws.amazon.com/q/developer/)**   |
 |        **[Cline](https://github.com/cline/cline)**        |               **[Antigravity](https://idx.google.com)**                |       **[Augment](https://www.augmentcode.com)**        |
 |             **[Cursor](https://cursor.com)**              | **[Gemini CLI](https://ai.google.dev/gemini-api/docs/code-execution)** |    **[Droid (Factory.ai)](https://www.factory.ai)**     |
-| **[GitHub Copilot](https://github.com/features/copilot)** |                  **[Kilo Code](https://kilocode.ai)**                  | **[OpenCode](https://github.com/opencode-ai/opencode)** |
+| **[GitHub Copilot](https://github.com/features/copilot)** |                  **[Kilo Code](https://kilocode.ai)**                  |           **[OpenCode](https://opencode.ai)**           |
 |       **[Windsurf](https://codeium.com/windsurf)**        |                     **[Kiro](https://kiro.dev/)**                      |  **[Sourcegraph Cody](https://sourcegraph.com/cody)**   |
 |                                                           |    **[OpenAI Codex](https://openai.com/index/introducing-codex/)**     |         **[Tabnine](https://www.tabnine.com)**          |
 |                                                           |                    **[Roo Code](https://roo.dev)**                     |                                                         |


### PR DESCRIPTION
## Summary
- Updates the OpenCode link in the Supported Agents table from the archived `github.com/opencode-ai/opencode` repo to the official site at `https://opencode.ai`.

Fixes #123 

## Test plan
- [x] Verified the OpenCode link resolves to the official OpenCode site
- [x] Confirmed no other references to the old URL remain in the repo