### PR TITLE
feat: add tlc-generative-engine-optimization skill (GEO - Generative Engine Optimization)

### DIFF
--- a/packages/skills-catalog/skills-registry.json
+++ b/packages/skills-catalog/skills-registry.json
@@ -68,10 +68,7 @@
       "description": "Audit and improve web accessibility following WCAG 2.1 guidelines. Use when asked to \"improve accessibility\", \"a11y audit\", \"WCAG compliance\", \"screen reader support\", \"keyboard navigation\", or \"make accessible\". Do NOT use for SEO (use seo), performance (use core-web-vitals), or comprehensive site audits covering multiple areas (use web-quality-audit).",
       "category": "quality",
       "path": "(quality)/web-accessibility",
-      "files": [
-        "SKILL.md",
-        "references/WCAG.md"
-      ],
+      "files": ["references/WCAG.md", "SKILL.md"],
       "author": "web-quality-skills",
       "version": "1.0",
       "contentHash": "706129400c8c91a9264582940b36007116faffcaf27bb0780bdab87337b4f881"
@@ -81,11 +78,7 @@
       "description": "\"When the user wants to build an AI-powered outreach system, write cold emails, improve deliverability, or scale personalized outreach. Also use when the user mentions 'cold email,' 'cold outreach,' 'outreach automation,' 'Instantly,' 'Smartlead,' 'Clay,' 'email sequences,' 'deliverability,' 'personalization at scale,' 'reply rate,' or 'outreach stack.' This skill covers the complete AI cold outreach system from signal detection through conversion. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/ai-cold-outreach",
-      "files": [
-        "SKILL.md",
-        "references/benchmarks-deliverability-tactics.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/benchmarks-deliverability-tactics.md", "references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "7a2ca1d3f443357b96f22ffce9fb6d5e19134bb5d723ea55ca939873b3777c12"
@@ -95,11 +88,7 @@
       "description": "\"When the user wants to price an AI product, choose a charge metric, design pricing tiers, or optimize margins. Also use when the user mentions 'AI pricing,' 'usage-based pricing,' 'consumption pricing,' 'outcome pricing,' 'BYOK,' 'bring your own key,' 'per-seat pricing,' 'pricing tiers,' 'AI margins,' 'cost per token,' or 'pricing model.' This skill covers pricing strategy, packaging, and margin management for AI-native products. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/ai-pricing",
-      "files": [
-        "SKILL.md",
-        "references/implementation-guide.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/implementation-guide.md", "references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "642a42cf94b8061aad642d84363bb4f60712af858c093bed6f2ec6135a3e7937"
@@ -109,11 +98,7 @@
       "description": "\"When the user wants to deploy AI sales development reps, automate sales qualification, build signal-to-action routing, or design AI agent architecture for sales. Also use when the user mentions 'AI SDR,' 'AI sales agent,' 'automated qualification,' 'signal routing,' 'sales automation,' '11x,' 'Artisan,' 'AiSDR,' 'AI BDR,' or 'autonomous sales.' This skill covers AI SDR deployment, qualification automation, and agent architecture for sales development. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/ai-sdr",
-      "files": [
-        "SKILL.md",
-        "references/implementation-guide.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/implementation-guide.md", "references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "3f36a4b65cb1fc97722341b9fb1849fcecf320be8a1d8892028fa45663719786"
@@ -123,9 +108,7 @@
       "description": "\"When the user wants to build programmatic SEO with AI, create competitor alternative pages, optimize for AI Overviews, or scale content production. Also use when the user mentions 'SEO,' 'programmatic SEO,' 'AI content,' 'competitor alternative pages,' 'AI Overviews,' 'search optimization,' 'DataForSEO,' 'content at scale,' 'keyword strategy,' or 'organic traffic.' This skill covers AI-powered SEO strategy from keyword research through programmatic page generation. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/ai-seo",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "8ff9c7d6181c37c92fb225a8559d50ee5413c20e6a7ae240e05bb6a532d64f9b"
@@ -135,9 +118,7 @@
       "description": "\"When the user wants to create UGC ad campaigns, recruit UGC creators, generate AI UGC content, or scale with user-generated content. Also use when the user mentions 'UGC,' 'user-generated content,' 'creator ads,' 'Spark Ads,' 'whitelisting,' 'AI UGC,' 'Arcads,' 'Creatify,' 'creator brief,' or 'UGC testing.' This skill covers the UGC growth framework from creator recruitment through AI-powered scaling. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/ai-ugc-ads",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "92f981122d6add656bd10cae4404fa94a79db93f3cad2cd978ef12a4eea51b83"
@@ -148,7 +129,6 @@
       "category": "cloud",
       "path": "(cloud)/aws-advisor",
       "files": [
-        "SKILL.md",
         "references/checklists.md",
         "references/decision-trees.md",
         "references/mcp-guide.md",
@@ -156,7 +136,8 @@
         "scripts/cost_considerations.py",
         "scripts/generate_diagram.py",
         "scripts/security_review.py",
-        "scripts/well_architected_review.py"
+        "scripts/well_architected_review.py",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.0",
@@ -167,9 +148,7 @@
       "description": "Apply modern web development best practices for security, compatibility, and code quality. Use when asked to \"apply best practices\", \"security audit\", \"modernize code\", \"code quality review\", or \"check for vulnerabilities\". Do NOT use for accessibility (use web-accessibility), SEO (use seo), performance (use core-web-vitals), or comprehensive multi-area audits (use web-quality-audit).",
       "category": "quality",
       "path": "(quality)/web-best-practices",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "web-quality-skills",
       "version": "1.0",
       "contentHash": "e22b6d3e9c7d29cc5f92a89a1a393aa2686aa5c0cd70b7159a7fc9a2bc779461"
@@ -179,9 +158,7 @@
       "description": "Browser debugging, performance profiling, and automation via Chrome DevTools MCP. Use when user says \"debug this page\", \"take a screenshot\", \"check network requests\", \"profile performance\", \"inspect console errors\", or \"analyze page load\". Do NOT use for full E2E test suites (use playwright-skill) or non-browser debugging.",
       "category": "tooling",
       "path": "(tooling)/chrome-devtools",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "249d0fb724d83a9dc1b81f5812b894d471b36e6e629407cd43f9b8135fe4630a"
     },
     {
@@ -191,314 +168,314 @@
       "path": "(cloud)/cloudflare-deploy",
       "files": [
         "LICENSE.txt",
-        "SKILL.md",
-        "references/agents-sdk/README.md",
         "references/agents-sdk/api.md",
         "references/agents-sdk/configuration.md",
         "references/agents-sdk/gotchas.md",
         "references/agents-sdk/patterns.md",
-        "references/ai-gateway/README.md",
+        "references/agents-sdk/README.md",
         "references/ai-gateway/configuration.md",
         "references/ai-gateway/dynamic-routing.md",
         "references/ai-gateway/features.md",
+        "references/ai-gateway/README.md",
         "references/ai-gateway/sdk-integration.md",
         "references/ai-gateway/troubleshooting.md",
-        "references/ai-search/README.md",
         "references/ai-search/api.md",
         "references/ai-search/configuration.md",
         "references/ai-search/gotchas.md",
         "references/ai-search/patterns.md",
-        "references/analytics-engine/README.md",
+        "references/ai-search/README.md",
         "references/analytics-engine/api.md",
         "references/analytics-engine/configuration.md",
         "references/analytics-engine/gotchas.md",
         "references/analytics-engine/patterns.md",
-        "references/api/README.md",
+        "references/analytics-engine/README.md",
         "references/api/api.md",
         "references/api/configuration.md",
         "references/api/gotchas.md",
         "references/api/patterns.md",
-        "references/api-shield/README.md",
+        "references/api/README.md",
         "references/api-shield/api.md",
         "references/api-shield/configuration.md",
         "references/api-shield/gotchas.md",
         "references/api-shield/patterns.md",
-        "references/argo-smart-routing/README.md",
+        "references/api-shield/README.md",
         "references/argo-smart-routing/api.md",
         "references/argo-smart-routing/configuration.md",
         "references/argo-smart-routing/gotchas.md",
         "references/argo-smart-routing/patterns.md",
-        "references/bindings/README.md",
+        "references/argo-smart-routing/README.md",
         "references/bindings/api.md",
         "references/bindings/configuration.md",
         "references/bindings/gotchas.md",
         "references/bindings/patterns.md",
-        "references/bot-management/README.md",
+        "references/bindings/README.md",
         "references/bot-management/api.md",
         "references/bot-management/configuration.md",
         "references/bot-management/gotchas.md",
         "references/bot-management/patterns.md",
-        "references/browser-rendering/README.md",
+        "references/bot-management/README.md",
         "references/browser-rendering/api.md",
         "references/browser-rendering/configuration.md",
         "references/browser-rendering/gotchas.md",
         "references/browser-rendering/patterns.md",
-        "references/c3/README.md",
+        "references/browser-rendering/README.md",
         "references/c3/api.md",
         "references/c3/configuration.md",
         "references/c3/gotchas.md",
         "references/c3/patterns.md",
-        "references/cache-reserve/README.md",
+        "references/c3/README.md",
         "references/cache-reserve/api.md",
         "references/cache-reserve/configuration.md",
         "references/cache-reserve/gotchas.md",
         "references/cache-reserve/patterns.md",
-        "references/containers/README.md",
+        "references/cache-reserve/README.md",
         "references/containers/api.md",
         "references/containers/configuration.md",
         "references/containers/gotchas.md",
         "references/containers/patterns.md",
-        "references/cron-triggers/README.md",
+        "references/containers/README.md",
         "references/cron-triggers/api.md",
         "references/cron-triggers/configuration.md",
         "references/cron-triggers/gotchas.md",
         "references/cron-triggers/patterns.md",
-        "references/d1/README.md",
+        "references/cron-triggers/README.md",
         "references/d1/api.md",
         "references/d1/configuration.md",
         "references/d1/gotchas.md",
         "references/d1/patterns.md",
-        "references/ddos/README.md",
+        "references/d1/README.md",
         "references/ddos/api.md",
         "references/ddos/configuration.md",
         "references/ddos/gotchas.md",
         "references/ddos/patterns.md",
-        "references/do-storage/README.md",
+        "references/ddos/README.md",
         "references/do-storage/api.md",
         "references/do-storage/configuration.md",
         "references/do-storage/gotchas.md",
         "references/do-storage/patterns.md",
+        "references/do-storage/README.md",
         "references/do-storage/testing.md",
-        "references/durable-objects/README.md",
         "references/durable-objects/api.md",
         "references/durable-objects/configuration.md",
         "references/durable-objects/gotchas.md",
         "references/durable-objects/patterns.md",
-        "references/email-routing/README.md",
+        "references/durable-objects/README.md",
         "references/email-routing/api.md",
         "references/email-routing/configuration.md",
         "references/email-routing/gotchas.md",
         "references/email-routing/patterns.md",
-        "references/email-workers/README.md",
+        "references/email-routing/README.md",
         "references/email-workers/api.md",
         "references/email-workers/configuration.md",
         "references/email-workers/gotchas.md",
         "references/email-workers/patterns.md",
-        "references/hyperdrive/README.md",
+        "references/email-workers/README.md",
         "references/hyperdrive/api.md",
         "references/hyperdrive/configuration.md",
         "references/hyperdrive/gotchas.md",
         "references/hyperdrive/patterns.md",
-        "references/images/README.md",
+        "references/hyperdrive/README.md",
         "references/images/api.md",
         "references/images/configuration.md",
         "references/images/gotchas.md",
         "references/images/patterns.md",
-        "references/kv/README.md",
+        "references/images/README.md",
         "references/kv/api.md",
         "references/kv/configuration.md",
         "references/kv/gotchas.md",
         "references/kv/patterns.md",
-        "references/miniflare/README.md",
+        "references/kv/README.md",
         "references/miniflare/api.md",
         "references/miniflare/configuration.md",
         "references/miniflare/gotchas.md",
         "references/miniflare/patterns.md",
-        "references/network-interconnect/README.md",
+        "references/miniflare/README.md",
         "references/network-interconnect/api.md",
         "references/network-interconnect/configuration.md",
         "references/network-interconnect/gotchas.md",
         "references/network-interconnect/patterns.md",
-        "references/observability/README.md",
+        "references/network-interconnect/README.md",
         "references/observability/api.md",
         "references/observability/configuration.md",
         "references/observability/gotchas.md",
         "references/observability/patterns.md",
-        "references/pages/README.md",
+        "references/observability/README.md",
         "references/pages/api.md",
         "references/pages/configuration.md",
         "references/pages/gotchas.md",
         "references/pages/patterns.md",
-        "references/pages-functions/README.md",
+        "references/pages/README.md",
         "references/pages-functions/api.md",
         "references/pages-functions/configuration.md",
         "references/pages-functions/gotchas.md",
         "references/pages-functions/patterns.md",
-        "references/pipelines/README.md",
+        "references/pages-functions/README.md",
         "references/pipelines/api.md",
         "references/pipelines/configuration.md",
         "references/pipelines/gotchas.md",
         "references/pipelines/patterns.md",
-        "references/pulumi/README.md",
+        "references/pipelines/README.md",
         "references/pulumi/api.md",
         "references/pulumi/configuration.md",
         "references/pulumi/gotchas.md",
         "references/pulumi/patterns.md",
-        "references/queues/README.md",
+        "references/pulumi/README.md",
         "references/queues/api.md",
         "references/queues/configuration.md",
         "references/queues/gotchas.md",
         "references/queues/patterns.md",
-        "references/r2/README.md",
+        "references/queues/README.md",
         "references/r2/api.md",
         "references/r2/configuration.md",
         "references/r2/gotchas.md",
         "references/r2/patterns.md",
-        "references/r2-data-catalog/README.md",
+        "references/r2/README.md",
         "references/r2-data-catalog/api.md",
         "references/r2-data-catalog/configuration.md",
         "references/r2-data-catalog/gotchas.md",
         "references/r2-data-catalog/patterns.md",
-        "references/r2-sql/README.md",
+        "references/r2-data-catalog/README.md",
         "references/r2-sql/api.md",
         "references/r2-sql/configuration.md",
         "references/r2-sql/gotchas.md",
         "references/r2-sql/patterns.md",
-        "references/realtime-sfu/README.md",
+        "references/r2-sql/README.md",
         "references/realtime-sfu/api.md",
         "references/realtime-sfu/configuration.md",
         "references/realtime-sfu/gotchas.md",
         "references/realtime-sfu/patterns.md",
-        "references/realtimekit/README.md",
+        "references/realtime-sfu/README.md",
         "references/realtimekit/api.md",
         "references/realtimekit/configuration.md",
         "references/realtimekit/gotchas.md",
         "references/realtimekit/patterns.md",
-        "references/sandbox/README.md",
+        "references/realtimekit/README.md",
         "references/sandbox/api.md",
         "references/sandbox/configuration.md",
         "references/sandbox/gotchas.md",
         "references/sandbox/patterns.md",
-        "references/secrets-store/README.md",
+        "references/sandbox/README.md",
         "references/secrets-store/api.md",
         "references/secrets-store/configuration.md",
         "references/secrets-store/gotchas.md",
         "references/secrets-store/patterns.md",
-        "references/smart-placement/README.md",
+        "references/secrets-store/README.md",
         "references/smart-placement/api.md",
         "references/smart-placement/configuration.md",
         "references/smart-placement/gotchas.md",
         "references/smart-placement/patterns.md",
-        "references/snippets/README.md",
+        "references/smart-placement/README.md",
         "references/snippets/api.md",
         "references/snippets/configuration.md",
         "references/snippets/gotchas.md",
         "references/snippets/patterns.md",
-        "references/spectrum/README.md",
+        "references/snippets/README.md",
         "references/spectrum/api.md",
         "references/spectrum/configuration.md",
         "references/spectrum/gotchas.md",
         "references/spectrum/patterns.md",
-        "references/static-assets/README.md",
+        "references/spectrum/README.md",
         "references/static-assets/api.md",
         "references/static-assets/configuration.md",
         "references/static-assets/gotchas.md",
         "references/static-assets/patterns.md",
-        "references/stream/README.md",
+        "references/static-assets/README.md",
         "references/stream/api-live.md",
         "references/stream/api.md",
         "references/stream/configuration.md",
         "references/stream/gotchas.md",
         "references/stream/patterns.md",
-        "references/tail-workers/README.md",
+        "references/stream/README.md",
         "references/tail-workers/api.md",
         "references/tail-workers/configuration.md",
         "references/tail-workers/gotchas.md",
         "references/tail-workers/patterns.md",
-        "references/terraform/README.md",
+        "references/tail-workers/README.md",
         "references/terraform/api.md",
         "references/terraform/configuration.md",
         "references/terraform/gotchas.md",
         "references/terraform/patterns.md",
-        "references/tunnel/README.md",
+        "references/terraform/README.md",
         "references/tunnel/api.md",
         "references/tunnel/configuration.md",
         "references/tunnel/gotchas.md",
         "references/tunnel/networking.md",
         "references/tunnel/patterns.md",
-        "references/turn/README.md",
+        "references/tunnel/README.md",
         "references/turn/api.md",
         "references/turn/configuration.md",
         "references/turn/gotchas.md",
         "references/turn/patterns.md",
-        "references/turnstile/README.md",
+        "references/turn/README.md",
         "references/turnstile/api.md",
         "references/turnstile/configuration.md",
         "references/turnstile/gotchas.md",
         "references/turnstile/patterns.md",
-        "references/vectorize/README.md",
+        "references/turnstile/README.md",
         "references/vectorize/api.md",
         "references/vectorize/configuration.md",
         "references/vectorize/gotchas.md",
         "references/vectorize/patterns.md",
-        "references/waf/README.md",
+        "references/vectorize/README.md",
         "references/waf/api.md",
         "references/waf/configuration.md",
         "references/waf/gotchas.md",
         "references/waf/patterns.md",
-        "references/web-analytics/README.md",
+        "references/waf/README.md",
         "references/web-analytics/configuration.md",
         "references/web-analytics/gotchas.md",
         "references/web-analytics/integration.md",
         "references/web-analytics/patterns.md",
-        "references/workerd/README.md",
+        "references/web-analytics/README.md",
         "references/workerd/api.md",
         "references/workerd/configuration.md",
         "references/workerd/gotchas.md",
         "references/workerd/patterns.md",
-        "references/workers/README.md",
+        "references/workerd/README.md",
         "references/workers/api.md",
         "references/workers/configuration.md",
         "references/workers/frameworks.md",
         "references/workers/gotchas.md",
         "references/workers/patterns.md",
-        "references/workers-ai/README.md",
+        "references/workers/README.md",
         "references/workers-ai/api.md",
         "references/workers-ai/configuration.md",
         "references/workers-ai/gotchas.md",
         "references/workers-ai/patterns.md",
-        "references/workers-for-platforms/README.md",
+        "references/workers-ai/README.md",
         "references/workers-for-platforms/api.md",
         "references/workers-for-platforms/configuration.md",
         "references/workers-for-platforms/gotchas.md",
         "references/workers-for-platforms/patterns.md",
-        "references/workers-playground/README.md",
+        "references/workers-for-platforms/README.md",
         "references/workers-playground/api.md",
         "references/workers-playground/configuration.md",
         "references/workers-playground/gotchas.md",
         "references/workers-playground/patterns.md",
-        "references/workers-vpc/README.md",
+        "references/workers-playground/README.md",
         "references/workers-vpc/api.md",
         "references/workers-vpc/configuration.md",
         "references/workers-vpc/gotchas.md",
         "references/workers-vpc/patterns.md",
-        "references/workflows/README.md",
+        "references/workers-vpc/README.md",
         "references/workflows/api.md",
         "references/workflows/configuration.md",
         "references/workflows/gotchas.md",
         "references/workflows/patterns.md",
-        "references/wrangler/README.md",
+        "references/workflows/README.md",
         "references/wrangler/api.md",
         "references/wrangler/auth.md",
         "references/wrangler/configuration.md",
         "references/wrangler/gotchas.md",
         "references/wrangler/patterns.md",
-        "references/zaraz/IMPLEMENTATION_SUMMARY.md",
-        "references/zaraz/README.md",
+        "references/wrangler/README.md",
         "references/zaraz/api.md",
         "references/zaraz/configuration.md",
         "references/zaraz/gotchas.md",
-        "references/zaraz/patterns.md"
+        "references/zaraz/IMPLEMENTATION_SUMMARY.md",
+        "references/zaraz/patterns.md",
+        "references/zaraz/README.md",
+        "SKILL.md"
       ],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
@@ -509,11 +486,7 @@
       "description": "Your pathfinder for navigating unknown codebases. Investigates with precision, implements surgically, and never assumes — if it doesn't know, it says so. Maintains a .notebook/ knowledge base that grows across sessions, turning every discovery into lasting intelligence. Summons available skills, MCPs, and docs when the mission demands. Use when fixing bugs, implementing features, refactoring, investigating flows, or any development task in unfamiliar territory. Triggers on \"fix this\", \"implement this\", \"how does this work\", \"investigate this flow\", \"help me with this code\". Do NOT use for greenfield scaffolding, CI/CD, or infrastructure provisioning.",
       "category": "development",
       "path": "(development)/codenavi",
-      "files": [
-        "SKILL.md",
-        "references/coding-principles.md",
-        "references/notebook-spec.md"
-      ],
+      "files": ["references/coding-principles.md", "references/notebook-spec.md", "SKILL.md"],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.0",
       "contentHash": "23ac05b7f2d8df8311129d41432eba248bdcf14e9ace3f17c581976f7d888ada"
@@ -523,9 +496,7 @@
       "description": "Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, modifying, or reviewing code — implementation tasks, code changes, refactoring, bug fixes, or feature development. Do NOT use for architecture design, documentation, or non-code tasks.",
       "category": "development",
       "path": "(development)/coding-guidelines",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "ale",
       "version": "1.0.0",
       "contentHash": "28a414c715d3c41aae28a25e2f109813ec3f246f76b5567c1e7d6a128cd289ff"
@@ -535,11 +506,7 @@
       "description": "Finds duplicate business logic spread across multiple components and suggests consolidation. Use when asking \"where is this logic duplicated?\", \"find common code between services\", \"what can be consolidated?\", \"detect shared domain logic\", or analyzing component overlap before refactoring. Do NOT use for code-level duplication detection (use linters) or dependency analysis (use coupling-analysis).",
       "category": "architecture",
       "path": "(architecture)/component-common-domain-detection",
-      "files": [
-        "QUICK-REFERENCE.md",
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["QUICK-REFERENCE.md", "README.md", "SKILL.md"],
       "contentHash": "58c72d63eaf387cf11ae36b223ff80478ba861f53265e42a3c4fbcb3bc739208"
     },
     {
@@ -547,11 +514,7 @@
       "description": "Detects misplaced classes and fixes component hierarchy problems — finds code that should belong inside a component but sits at the root level. Use when asking \"clean up component structure\", \"find orphaned classes\", \"fix module hierarchy\", \"flatten nested components\", or analyzing why namespaces have misplaced code. Do NOT use for dependency analysis (use coupling-analysis) or domain grouping (use domain-identification-grouping).",
       "category": "architecture",
       "path": "(architecture)/component-flattening-analysis",
-      "files": [
-        "QUICK-REFERENCE.md",
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["QUICK-REFERENCE.md", "README.md", "SKILL.md"],
       "contentHash": "085696b944897a2d8c96efb6e0a3faab00f910a62a49a45c3293c32458962411"
     },
     {
@@ -559,11 +522,7 @@
       "description": "Maps architectural components in a codebase and measures their size to identify what should be extracted first. Use when asking \"how big is each module?\", \"what components do I have?\", \"which service is too large?\", \"analyze codebase structure\", \"size my monolith\", or planning where to start decomposing. Do NOT use for runtime performance sizing or infrastructure capacity planning.",
       "category": "architecture",
       "path": "(architecture)/component-identification-sizing",
-      "files": [
-        "QUICK-REFERENCE.md",
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["QUICK-REFERENCE.md", "README.md", "SKILL.md"],
       "contentHash": "8ec5eb90e86cc84a346f15f50c86960d8f4ba6876f6fe27d687a1ba43a2448a0"
     },
     {
@@ -571,9 +530,7 @@
       "description": "Expert in Confluence operations using Atlassian MCP. Use when the user says \"search Confluence\", \"create a Confluence page\", \"update a page\", \"find documentation in Confluence\", \"list spaces\", or \"add a comment to a page\". Do NOT use for Jira issues, general web search, or local file creation.",
       "category": "development",
       "path": "(development)/confluence-assistant",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Waldemar Neto - github.com/waldemarnt",
       "version": "1.0.0",
       "contentHash": "b9f019173a7d864db1d0a9eca13ee920d294806ea4c5cabfb626ccaedbaaeae7"
@@ -583,11 +540,7 @@
       "description": "\"When the user wants to turn content into revenue, build a content-led GTM motion, reverse engineer distribution, or repurpose content across platforms. Also use when the user mentions 'content marketing,' 'content-led growth,' 'content to pipeline,' 'distribution,' 'content repurposing,' 'content strategy,' 'thought leadership,' 'newsletter,' 'content flywheel,' 'organic growth.' This skill covers content-to-revenue systems from creation through pipeline attribution. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/content-to-pipeline",
-      "files": [
-        "SKILL.md",
-        "references/podcast-community-cadence.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/podcast-community-cadence.md", "references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "925f769a4c601ea7fac8cab4d3ee00f799921eb0600427d18f458eb35db2e2ed"
@@ -597,10 +550,7 @@
       "description": "Optimize Core Web Vitals (LCP, INP, CLS) for better page experience and search ranking. Use when asked to \"improve Core Web Vitals\", \"fix LCP\", \"reduce CLS\", \"optimize INP\", \"page experience optimization\", or \"fix layout shifts\". Focuses specifically on the three Core Web Vitals metrics. Do NOT use for general web performance (use perf-web-optimization), Lighthouse audits (use perf-lighthouse), or Astro-specific optimization (use perf-astro).",
       "category": "performance",
       "path": "(performance)/core-web-vitals",
-      "files": [
-        "SKILL.md",
-        "references/LCP.md"
-      ],
+      "files": ["references/LCP.md", "SKILL.md"],
       "author": "web-quality-skills",
       "version": "1.0",
       "contentHash": "3a67190e1dea1f2573d4fbb17071bbdac5ff4fd087d8cb5271094851c2acd559"
@@ -610,9 +560,7 @@
       "description": "Analyzes coupling between modules using the three-dimensional model (strength, distance, volatility) from \"Balancing Coupling in Software Design\". Use when asking \"are these modules too coupled?\", \"show me dependencies\", \"analyze integration quality\", \"which modules should I decouple?\", \"coupling report\", or evaluating architectural health. Do NOT use for domain boundary analysis (use domain-analysis) or component sizing (use component-identification-sizing).",
       "category": "architecture",
       "path": "(architecture)/coupling-analysis",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "a33a142a73ac2e6b8db300acb3d13dba5077e225cbfad7599b0ac431290ab5c7"
     },
     {
@@ -620,10 +568,7 @@
       "description": "Creates Architecture Decision Records (ADRs) to document significant architectural choices and their rationale for future team members. Use when the user says \"write an ADR\", \"document this decision\", \"record why we chose X\", \"add an architecture decision record\", \"create an ADR for\", or wants to capture the reasoning behind a technical choice so the team understands it later. Do NOT use when the decision hasn't been made yet (use create-rfc instead), for implementation planning (use technical-design-doc-creator), or for general documentation.",
       "category": "creation",
       "path": "(creation)/create-adr",
-      "files": [
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["README.md", "SKILL.md"],
       "author": "Tech Leads Club - github.com/tech-leads-club",
       "version": "1.0.0",
       "contentHash": "47ec663c849e8c1620c6f33a7be0055acdcf838c27ab7c16f44260244b80195a"
@@ -633,11 +578,7 @@
       "description": "Creates structured Request for Comments (RFC) documents for proposing and deciding on significant changes. Use when the user says \"write an RFC\", \"create a proposal\", \"I need to propose a change\", \"draft an RFC\", \"document a decision\", or needs stakeholder alignment before making a major technical or process decision. Do NOT use for TDDs/implementation docs (use technical-design-doc-creator instead), README files, or general documentation.",
       "category": "creation",
       "path": "(creation)/create-rfc",
-      "files": [
-        "README.md",
-        "SKILL.md",
-        "references/section-templates.md"
-      ],
+      "files": ["README.md", "references/section-templates.md", "SKILL.md"],
       "author": "Tech Leads Club - github.com/tech-leads-club",
       "version": "1.0.0",
       "contentHash": "3f391b6c4397bb1590bbad511eca95c297dd0467e65385fa28b3724851c42ea8"
@@ -647,9 +588,7 @@
       "description": "Creates Cursor-specific AI subagents with isolated context for complex multi-step workflows. Use when creating subagents for Cursor editor specifically, following Cursor's patterns and directories (.cursor/agents/). Triggers on \"cursor subagent\", \"cursor agent\". Do NOT use for generic subagent creation outside Cursor (use subagent-creator instead).",
       "category": "creation",
       "path": "(creation)/cursor-subagent-creator",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "658a170d783a694e638814bed35a738184795da2d0f0b36489cac94a478cd8d7"
     },
     {
@@ -657,11 +596,7 @@
       "description": "Creates step-by-step decomposition plans and migration roadmaps for breaking apart monolithic applications. Use when asking \"what order should I extract services?\", \"plan my migration\", \"create a decomposition roadmap\", \"prioritize what to split\", \"monolith to microservices strategy\", or tracking decomposition progress. Do NOT use for domain analysis (use domain-analysis) or component sizing (use component-identification-sizing).",
       "category": "architecture",
       "path": "(architecture)/decomposition-planning-roadmap",
-      "files": [
-        "QUICK-REFERENCE.md",
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["QUICK-REFERENCE.md", "README.md", "SKILL.md"],
       "contentHash": "8de88d993b2556a6b38c26fd79c863f06bf7746faf87c0c9fd1b9a198a49e1ac"
     },
     {
@@ -669,10 +604,7 @@
       "description": "Write, review, and edit documentation files with consistent structure, tone, and technical accuracy. Use when creating docs, reviewing markdown files, writing READMEs, updating `/docs` directories, or when user says \"write documentation\", \"review this doc\", \"improve this README\", \"create a guide\", or \"edit markdown\". Do NOT use for code comments, inline JSDoc, or API reference generation.",
       "category": "development",
       "path": "(development)/docs-writer",
-      "files": [
-        "SKILL.md",
-        "references/style-guide.md"
-      ],
+      "files": ["references/style-guide.md", "SKILL.md"],
       "contentHash": "c49827c59d2e27d313731dfd36314cfde0e8dbf15be0e8f813d2f8b751546b0c"
     },
     {
@@ -680,12 +612,7 @@
       "description": "Maps business domains and suggests service boundaries in any codebase using DDD Strategic Design. Use when asking \"what are the domains in this codebase?\", \"where should I draw service boundaries?\", \"identify bounded contexts\", \"classify subdomains\", \"DDD analysis\", or analyzing domain cohesion. Do NOT use for grouping existing components into domains (use domain-identification-grouping) or dependency analysis (use coupling-analysis).",
       "category": "architecture",
       "path": "(architecture)/domain-analysis",
-      "files": [
-        "EXAMPLES.md",
-        "QUICK-REFERENCE.md",
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["EXAMPLES.md", "QUICK-REFERENCE.md", "README.md", "SKILL.md"],
       "contentHash": "5914beeaf1aa1fe57cd95cf0afb60ee1cccc58eedaddd123a43cad32d6a70077"
     },
     {
@@ -693,11 +620,7 @@
       "description": "Groups existing components into logical business domains to plan service-based architecture. Use when asking \"which components belong together?\", \"group these into services\", \"organize by domain\", \"component-to-domain mapping\", or planning service extraction from an existing codebase. Do NOT use for identifying new domains from scratch (use domain-analysis) or analyzing coupling (use coupling-analysis).",
       "category": "architecture",
       "path": "(architecture)/domain-identification-grouping",
-      "files": [
-        "QUICK-REFERENCE.md",
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["QUICK-REFERENCE.md", "README.md", "SKILL.md"],
       "contentHash": "ac3c94d9910a75aa6a61f7866507d16a3c646ff17e86b79667d1a19c6fa6c659"
     },
     {
@@ -706,7 +629,6 @@
       "category": "tooling",
       "path": "(tooling)/excalidraw-studio",
       "files": [
-        "SKILL.md",
         "assets/business-flow-swimlane-template.json",
         "assets/class-diagram-template.json",
         "assets/data-flow-diagram-template.json",
@@ -718,10 +640,11 @@
         "references/element-types.md",
         "references/excalidraw-schema.md",
         "references/icon-libraries.md",
-        "scripts/README.md",
         "scripts/add-arrow.py",
         "scripts/add-icon-to-diagram.py",
-        "scripts/split-excalidraw-library.py"
+        "scripts/README.md",
+        "scripts/split-excalidraw-library.py",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.1",
@@ -732,9 +655,7 @@
       "description": "\"When the user wants to reduce churn, build expansion revenue, automate customer success, or optimize net revenue retention. Also use when the user mentions 'churn,' 'retention,' 'expansion revenue,' 'upsell,' 'NRR,' 'net revenue retention,' 'customer success,' 'land and expand,' 'closed-lost,' or 'renewal.' This skill covers expansion and retention systems from usage triggers through automated customer success. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/expansion-retention",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "e5420a123058969e8e5014d74120daf7a1c598e1fb44e6d152c6b60a71a81e95"
@@ -744,12 +665,7 @@
       "description": "Use the Figma MCP server to fetch design context, screenshots, variables, and assets from Figma, and to translate Figma nodes into production code. Use when a task involves Figma URLs, node IDs, design-to-code implementation, or Figma MCP setup and troubleshooting. Covers general Figma data fetching and exploration. Do NOT use when the goal is specifically pixel-perfect code implementation from a Figma design (use figma-implement-design instead).",
       "category": "design",
       "path": "(design)/figma",
-      "files": [
-        "LICENSE.txt",
-        "SKILL.md",
-        "references/figma-mcp-config.md",
-        "references/figma-tools-and-prompts.md"
-      ],
+      "files": ["LICENSE.txt", "references/figma-mcp-config.md", "references/figma-tools-and-prompts.md", "SKILL.md"],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
       "contentHash": "5da2000639e7aee302556408a161168b8955758da0da3305842e14a93a40a7b7"
@@ -759,10 +675,7 @@
       "description": "Translate Figma nodes into production-ready code with 1:1 visual fidelity using the Figma MCP workflow (design context, screenshots, assets, and project-convention translation). Use when the user provides Figma URLs or node IDs and asks to implement designs or components that must match Figma specs. Requires a working Figma MCP server connection. Do NOT use for general Figma data fetching, variable exploration, or MCP troubleshooting (use figma instead).",
       "category": "design",
       "path": "(design)/figma-implement-design",
-      "files": [
-        "LICENSE.txt",
-        "SKILL.md"
-      ],
+      "files": ["LICENSE.txt", "SKILL.md"],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
       "contentHash": "6177778eac45026cf58d1f86447fa730e39389e54a99df2c5f35cd6905371b1d"
@@ -773,10 +686,10 @@
       "category": "architecture",
       "path": "(architecture)/frontend-blueprint",
       "files": [
-        "SKILL.md",
         "references/collection-guide.md",
         "references/design-principles.md",
-        "references/stitch-integration.md"
+        "references/stitch-integration.md",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.0",
@@ -788,14 +701,14 @@
       "category": "design",
       "path": "(design)/frontend-design",
       "files": [
-        "SKILL.md",
         "references/color-and-contrast.md",
         "references/interaction-design.md",
         "references/motion-design.md",
         "references/responsive-design.md",
         "references/spatial-design.md",
         "references/typography.md",
-        "references/ux-writing.md"
+        "references/ux-writing.md",
+        "SKILL.md"
       ],
       "author": "Impeccable (Paul Bakaus), based on Anthropic frontend-design",
       "version": "1.0.0",
@@ -806,11 +719,7 @@
       "description": "Address review and issue comments on the open GitHub PR for the current branch using gh CLI. Use when user says \"address PR comments\", \"fix review feedback\", \"respond to PR review\", or \"handle PR comments\". Verifies gh auth first and prompts to authenticate if not logged in. Do NOT use for creating PRs, CI debugging (use gh-fix-ci), or general Git operations.",
       "category": "development",
       "path": "(development)/gh-address-comments",
-      "files": [
-        "LICENSE.txt",
-        "SKILL.md",
-        "scripts/fetch_comments.py"
-      ],
+      "files": ["LICENSE.txt", "scripts/fetch_comments.py", "SKILL.md"],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
       "contentHash": "a1808fb136b7118a7bdac65415e9a40a7982953f8b3339c97087fc0807865d88"
@@ -820,11 +729,7 @@
       "description": "Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions. Uses `gh` to inspect checks and logs, summarize failure context, draft a fix plan, and implement only after explicit approval. Treats external providers (for example Buildkite) as out of scope and reports only the details URL. Do NOT use for addressing PR review comments (use gh-address-comments) or general CI outside GitHub Actions.",
       "category": "tooling",
       "path": "(tooling)/gh-fix-ci",
-      "files": [
-        "LICENSE.txt",
-        "SKILL.md",
-        "scripts/inspect_pr_checks.py"
-      ],
+      "files": ["LICENSE.txt", "scripts/inspect_pr_checks.py", "SKILL.md"],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
       "contentHash": "f032610bcbf7f7a7b6b13d20de360608c10328b7a9e507610323e843d613f1f4"
@@ -834,11 +739,7 @@
       "description": "\"When the user wants to build GTM automation with code, design workflow architectures, use AI agents for GTM tasks, or implement the 'architecture over tools' principle. Also use when the user mentions 'GTM engineering,' 'GTM automation,' 'n8n,' 'Make,' 'Zapier,' 'workflow automation,' 'Clay API,' 'instruction stacks,' 'AI agents for GTM,' or 'revenue automation.' This skill covers technical GTM infrastructure from workflow design through agent orchestration. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/gtm-engineering",
-      "files": [
-        "SKILL.md",
-        "references/implementation-guide.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/implementation-guide.md", "references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "b2cfbea2da9f2a52527f6c41f128df2dba76c33df90692357a5533c06b78223f"
@@ -848,9 +749,7 @@
       "description": "\"When the user wants to define GTM metrics, build a metrics dashboard, measure pipeline efficiency, or track AI product performance. Also use when the user mentions 'GTM metrics,' 'revenue latency,' 'pipeline metrics,' 'TTFV,' 'time-to-first-value,' 'data health,' 'attribution,' 'conversion rate,' 'CAC,' 'LTV,' 'NRR,' 'GTM dashboard,' 'magic number,' 'pipeline velocity,' or 'funnel metrics.' This skill covers GTM measurement from metric selection through dashboard design, including AI-specific cost metrics, attribution models, and weekly review cadences. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/gtm-metrics",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "9f2afa96826b0456cf79f05b43ab4470fd6802990e301bb898c2cbaa6f01cf5c"
@@ -860,10 +759,7 @@
       "description": "Manage Jira issues via Atlassian MCP — search, create, update, transition status, and handle sprint tasks. Auto-detects workspace configuration. Use when user says \"create a Jira ticket\", \"update my sprint\", \"check Jira status\", \"transition this issue\", \"search Jira\", or \"move ticket to done\". Do NOT use for Confluence pages (use confluence-assistant).",
       "category": "development",
       "path": "(development)/jira-assistant",
-      "files": [
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["README.md", "SKILL.md"],
       "contentHash": "fa63880889d2206548e33489a0ac1aa849c4e6ab879ea769c2715521a8231c8a"
     },
     {
@@ -871,10 +767,7 @@
       "description": "\"When the user wants to build data enrichment workflows, score leads against ICP, set up Clay waterfalls, or improve contact data quality. Also use when the user mentions 'enrichment,' 'data enrichment,' 'Clay,' 'waterfall enrichment,' 'ICP scoring,' 'lead scoring,' 'intent data,' 'contact verification,' 'Apollo,' 'ZoomInfo,' or 'data quality.' This skill covers lead enrichment waterfalls, ICP scoring frameworks, and contact verification systems. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/lead-enrichment",
-      "files": [
-        "SKILL.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "c062dadf96d7a1500457c222b95baff7f5aade66486044be360a13268b251940"
@@ -884,10 +777,7 @@
       "description": "Facilitates deliberate skill development during AI-assisted coding. Offers interactive learning exercises after architectural work (new files, schema changes, refactors). Use when completing features, making design decisions, or when user asks to understand code better. Triggers on \"learning exercise\", \"help me understand\", \"teach me\", \"why does this work\", or after creating new files/modules. Do NOT use for urgent debugging, quick fixes, or when user says \"just ship it\".",
       "category": "learning",
       "path": "(learning)/learning-opportunities",
-      "files": [
-        "SKILL.md",
-        "references/PRINCIPLES.md"
-      ],
+      "files": ["references/PRINCIPLES.md", "SKILL.md"],
       "author": "Chris Hicks",
       "version": "1.1.0",
       "contentHash": "47c4d62eebf29a61477c1b611c6ae360b028e1e23e09df1f6a33b5ff32b020f7"
@@ -898,13 +788,13 @@
       "category": "architecture",
       "path": "(architecture)/legacy-migration-planner",
       "files": [
-        "SKILL.md",
         "references/assessment-framework.md",
         "references/frontend-backend-strategies.md",
         "references/plan-phase.md",
         "references/research-phase.md",
         "references/strangler-fig-patterns.md",
-        "references/testing-safety-nets.md"
+        "references/testing-safety-nets.md",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.0",
@@ -916,7 +806,6 @@
       "category": "tooling",
       "path": "(tooling)/mermaid-studio",
       "files": [
-        "SKILL.md",
         "assets/puppeteer-config.json",
         "references/aws-architecture.md",
         "references/c4-architecture.md",
@@ -928,7 +817,8 @@
         "scripts/render-ascii.mjs",
         "scripts/render.mjs",
         "scripts/setup.sh",
-        "scripts/validate.mjs"
+        "scripts/validate.mjs",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.1",
@@ -940,7 +830,6 @@
       "category": "architecture",
       "path": "(architecture)/modular-decomposition",
       "files": [
-        "SKILL.md",
         "references/domain-analysis-examples.md",
         "references/domain-analysis-quick-reference.md",
         "references/domain-analysis.md",
@@ -952,7 +841,8 @@
         "references/pattern-03-flattening.md",
         "references/pattern-04-coupling.md",
         "references/pattern-05-domain-grouping-quick-reference.md",
-        "references/pattern-05-domain-grouping.md"
+        "references/pattern-05-domain-grouping.md",
+        "SKILL.md"
       ],
       "contentHash": "b536c1851c862516e5fc111502311343b952073a992ea07c9f8f9b42fbbc2a44"
     },
@@ -961,10 +851,7 @@
       "description": ">",
       "category": "architecture",
       "path": "(architecture)/modular-design-principles",
-      "files": [
-        "SKILL.md",
-        "references/principles.md"
-      ],
+      "files": ["references/principles.md", "SKILL.md"],
       "contentHash": "d53fdca7ae18205376956c39a3a1729edfae843f63e5f2a6c5dd2c64ccd8a576"
     },
     {
@@ -972,11 +859,7 @@
       "description": "\"When the user wants to launch a product across multiple platforms, plan a Product Hunt launch, build a waitlist, or execute a multi-channel launch strategy. Also use when the user mentions 'product launch,' 'Product Hunt,' 'launch strategy,' 'waitlist,' 'beta launch,' 'BetaList,' 'Hacker News,' 'launch day,' 'AppSumo,' 'multi-channel launch.' This skill covers multi-platform launch execution from pre-launch through post-launch optimization. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/multi-platform-launch",
-      "files": [
-        "SKILL.md",
-        "references/directories-timing-mistakes.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/directories-timing-mistakes.md", "references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "22552e0a3fde93c57715295f52b31d0695ad78d10512e5793ea93c7b138c79ee"
@@ -987,14 +870,14 @@
       "category": "development",
       "path": "(development)/nestjs-modular-monolith",
       "files": [
-        "SKILL.md",
         "references/architecture-patterns.md",
         "references/authentication.md",
         "references/module-communication.md",
         "references/stack-configuration.md",
         "references/state-isolation.md",
         "references/testing-patterns.md",
-        "scripts/validate-isolation.sh"
+        "scripts/validate-isolation.sh",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.0",
@@ -1007,10 +890,10 @@
       "path": "(cloud)/netlify-deploy",
       "files": [
         "LICENSE.txt",
-        "SKILL.md",
         "references/cli-commands.md",
         "references/deployment-patterns.md",
-        "references/netlify-toml.md"
+        "references/netlify-toml.md",
+        "SKILL.md"
       ],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
@@ -1021,9 +904,7 @@
       "description": "Monitor Nx Cloud CI pipeline status and handle self-healing fixes automatically. Use when user says \"watch CI\", \"monitor pipeline\", \"check CI status\", \"fix CI failures\", or \"self-heal CI\". Requires Nx Cloud connection. Do NOT use for local task execution (use nx-run-tasks) or general CI debugging outside Nx Cloud.",
       "category": "tooling",
       "path": "(tooling)/nx-ci-monitor",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "ddb5bf9bd2a5ca0eac8fa01632a19569baed922201b2cc501975edd77697f75c"
     },
     {
@@ -1031,9 +912,7 @@
       "description": "Generate code using Nx generators — scaffold projects, libraries, features, or run workspace-specific generators with proper discovery, validation, and verification. Use when user says \"create a new library\", \"scaffold a component\", \"generate code with Nx\", \"run a generator\", \"nx generate\", or any code scaffolding task in a monorepo. Prefers local workspace-plugin generators over external plugins. Do NOT use for running build/test/lint tasks (use nx-run-tasks) or workspace configuration (use nx-workspace).",
       "category": "tooling",
       "path": "(tooling)/nx-generate",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "b975e1a0caa6cc9922ba941e0746a2f141c708e41c8bbddb395d40e3efecf2a0"
     },
     {
@@ -1041,9 +920,7 @@
       "description": "Execute build, test, lint, serve, and other tasks in an Nx workspace using single runs, run-many, and affected commands. Use when user says \"run tests\", \"build my app\", \"lint affected\", \"serve the project\", \"run all tasks\", or \"nx affected\". Do NOT use for code generation (use nx-generate) or workspace configuration (use nx-workspace).",
       "category": "tooling",
       "path": "(tooling)/nx-run-tasks",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "3c4d49d795b02e6a4a82606891a7da4773c3bc1ef883c1b980ac17596883397f"
     },
     {
@@ -1052,11 +929,11 @@
       "category": "tooling",
       "path": "(tooling)/nx-workspace",
       "files": [
-        "SKILL.md",
         "reference/best-practices.md",
         "reference/ci-cd.md",
         "reference/commands.md",
-        "reference/configuration.md"
+        "reference/configuration.md",
+        "SKILL.md"
       ],
       "contentHash": "410aad2cc5a3cdaf3ffc04b0a4ad893f6cf2f5babdd836e6eda68f409d3c7bf6"
     },
@@ -1065,10 +942,7 @@
       "description": "\"When the user wants to create AI-generated ad creative, test performance creative, manage creative fatigue, or optimize paid media with AI tools. Also use when the user mentions 'ad creative,' 'performance creative,' 'creative testing,' 'creative fatigue,' 'Meta ads,' 'Google ads,' 'TikTok ads,' 'AI ads,' 'ad budget,' 'ROAS,' 'Advantage+,' or 'Performance Max.' This skill covers AI-powered paid creative from generation through performance optimization. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/paid-creative-ai",
-      "files": [
-        "SKILL.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "89328ab72ff4336917031a217f43bd19b133a7d17202bf70d8d8d7f59d69ce29"
@@ -1078,11 +952,7 @@
       "description": "\"When the user wants to build a partner program, launch an affiliate program, design integration partnerships, or create distribution partnerships. Also use when the user mentions 'partnerships,' 'affiliate program,' 'referral program,' 'partner ecosystem,' 'integration partner,' 'reseller,' 'co-marketing,' 'PartnerStack,' or 'revenue share.' This skill covers partner and affiliate program design from recruitment through performance optimization. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/partner-affiliate",
-      "files": [
-        "SKILL.md",
-        "references/implementation-guide.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/implementation-guide.md", "references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "3ff5e89d89da30e46eef1d6fa4379aa1b41c30be16e2ca761a5581267c41561e"
@@ -1092,9 +962,7 @@
       "description": "'Astro-specific performance optimizations for 95+ Lighthouse scores. Covers critical CSS inlining, compression, font loading, and LCP optimization. Use when optimizing Astro site performance, improving Astro Lighthouse scores, or configuring astro-critters. Do NOT use for non-Astro sites (use perf-web-optimization or core-web-vitals) or running Lighthouse audits (use perf-lighthouse).'",
       "category": "performance",
       "path": "(performance)/perf-astro",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "11b50b27564085d9bff6d558bd4e9f31e5bce3c9a82af4c7203d9a4cd1ff43e4"
     },
     {
@@ -1102,9 +970,7 @@
       "description": "'Run Lighthouse audits locally via CLI or Node API, parse and interpret reports, and set performance budgets. Use when measuring site performance, understanding Lighthouse scores, setting up budgets, or integrating audits into CI. Triggers on: lighthouse, run lighthouse, lighthouse score, performance audit, performance budget. Do NOT use for fixing specific performance issues (use perf-web-optimization or core-web-vitals) or Astro-specific optimization (use perf-astro).'",
       "category": "performance",
       "path": "(performance)/perf-lighthouse",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "2ef96cebc94fda975a7bba9e37511bff65739c91e61b950be0bd3048b8c9760d"
     },
     {
@@ -1113,10 +979,10 @@
       "category": "performance",
       "path": "(performance)/perf-web-optimization",
       "files": [
-        "SKILL.md",
         "references/bundle-optimization.md",
         "references/core-web-vitals.md",
-        "references/image-optimization.md"
+        "references/image-optimization.md",
+        "SKILL.md"
       ],
       "contentHash": "864bb35d6ec7e7755181886b57709b76d8b5da5181a6d8480cd412dd772f1ffb"
     },
@@ -1125,13 +991,7 @@
       "description": "Complete browser automation with Playwright. Auto-detects dev servers, writes clean test scripts to /tmp. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use when user wants to test websites, automate browser interactions, validate web functionality, or perform any browser-based testing. Do NOT use for quick page debugging or network inspection (use chrome-devtools instead).",
       "category": "web-automation",
       "path": "(web-automation)/playwright-skill",
-      "files": [
-        "API_REFERENCE.md",
-        "SKILL.md",
-        "lib/helpers.js",
-        "package.json",
-        "run.js"
-      ],
+      "files": ["API_REFERENCE.md", "lib/helpers.js", "package.json", "run.js", "SKILL.md"],
       "contentHash": "9c45020d33af9ac2d44c89721f154c94bd73b9d8590117597b9a26920ff9cecc"
     },
     {
@@ -1139,10 +999,7 @@
       "description": "\"When the user wants to define their ideal customer profile, position an AI product, build messaging architecture, or validate product-market fit. Also use when the user mentions 'ICP,' 'ideal customer profile,' 'positioning,' 'PMF,' 'product-market fit,' 'messaging,' 'buyer persona,' 'enrichment signals,' 'market positioning,' or 'competitive positioning.' This skill covers market positioning, ICP definition, messaging architecture, and PMF validation for AI-native products. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/positioning-icp",
-      "files": [
-        "SKILL.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "3b940bcd8ad2035177bffb04e34d52fe038f669a2d466e8d67e73135044373a5"
@@ -1155,9 +1012,6 @@
       "files": [
         "AGENTS.md",
         "README.md",
-        "SKILL.md",
-        "rules/_sections.md",
-        "rules/_template.md",
         "rules/advanced-event-handler-refs.md",
         "rules/advanced-init-once.md",
         "rules/advanced-use-latest.md",
@@ -1214,7 +1068,10 @@
         "rules/server-cache-react.md",
         "rules/server-dedup-props.md",
         "rules/server-parallel-fetching.md",
-        "rules/server-serialization.md"
+        "rules/server-serialization.md",
+        "rules/_sections.md",
+        "rules/_template.md",
+        "SKILL.md"
       ],
       "author": "vercel",
       "version": "1.0.0",
@@ -1228,9 +1085,6 @@
       "files": [
         "AGENTS.md",
         "README.md",
-        "SKILL.md",
-        "rules/_sections.md",
-        "rules/_template.md",
         "rules/architecture-avoid-boolean-props.md",
         "rules/architecture-compound-components.md",
         "rules/patterns-children-over-render-props.md",
@@ -1238,7 +1092,10 @@
         "rules/react19-no-forwardref.md",
         "rules/state-context-interface.md",
         "rules/state-decouple-implementation.md",
-        "rules/state-lift-state.md"
+        "rules/state-lift-state.md",
+        "rules/_sections.md",
+        "rules/_template.md",
+        "SKILL.md"
       ],
       "author": "vercel",
       "version": "1.0.0",
@@ -1250,12 +1107,12 @@
       "category": "development",
       "path": "(development)/react-native-expert",
       "files": [
-        "SKILL.md",
         "references/expo-router.md",
         "references/performance-rules.md",
         "references/platform-handling.md",
         "references/project-structure.md",
-        "references/storage-patterns.md"
+        "references/storage-patterns.md",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.0",
@@ -1268,7 +1125,6 @@
       "path": "(cloud)/render-deploy",
       "files": [
         "LICENSE.txt",
-        "SKILL.md",
         "references/blueprint-spec.md",
         "references/codebase-analysis.md",
         "references/configuration-guide.md",
@@ -1278,7 +1134,8 @@
         "references/post-deploy-checks.md",
         "references/runtimes.md",
         "references/service-types.md",
-        "references/troubleshooting-basics.md"
+        "references/troubleshooting-basics.md",
+        "SKILL.md"
       ],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
@@ -1289,10 +1146,7 @@
       "description": "\"When the user wants to choose between PLG and sales-led, design a sales motion, optimize time-to-first-value, or build a value-before-purchase experience. Also use when the user mentions 'PLG,' 'product-led growth,' 'sales-led,' 'sales motion,' 'free trial,' 'freemium,' 'self-serve,' 'demo-first,' 'time-to-first-value,' 'TTFV,' or 'agent-led sales.' This skill covers sales motion selection, value delivery design, and go-to-market motion architecture. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/sales-motion-design",
-      "files": [
-        "SKILL.md",
-        "references/quick-reference.md"
-      ],
+      "files": ["references/quick-reference.md", "SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "8f9829a2107c994a3a4d2fcaec73def4bcc1a7fac20c64b452093a4e7018e93f"
@@ -1304,7 +1158,6 @@
       "path": "(security)/security-best-practices",
       "files": [
         "LICENSE.txt",
-        "SKILL.md",
         "references/golang-general-backend-security.md",
         "references/javascript-express-web-server-security.md",
         "references/javascript-general-web-frontend-security.md",
@@ -1314,7 +1167,8 @@
         "references/javascript-typescript-vue-web-frontend-security.md",
         "references/python-django-web-server-security.md",
         "references/python-fastapi-web-server-security.md",
-        "references/python-flask-web-server-security.md"
+        "references/python-flask-web-server-security.md",
+        "SKILL.md"
       ],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
@@ -1327,12 +1181,12 @@
       "path": "(security)/security-ownership-map",
       "files": [
         "LICENSE.txt",
-        "SKILL.md",
         "references/neo4j-import.md",
         "scripts/build_ownership_map.py",
         "scripts/community_maintainers.py",
         "scripts/query_ownership.py",
-        "scripts/run_ownership_map.py"
+        "scripts/run_ownership_map.py",
+        "SKILL.md"
       ],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
@@ -1345,9 +1199,9 @@
       "path": "(security)/security-threat-model",
       "files": [
         "LICENSE.txt",
-        "SKILL.md",
         "references/prompt-template.md",
-        "references/security-controls-and-assets.md"
+        "references/security-controls-and-assets.md",
+        "SKILL.md"
       ],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
@@ -1358,11 +1212,7 @@
       "description": "Inspect Sentry issues, summarize production errors, and pull health data via the Sentry API (read-only). Use when user says \"check Sentry\", \"what errors in production?\", \"summarize Sentry issues\", \"recent crashes\", or \"production error report\". Requires SENTRY_AUTH_TOKEN. Do NOT use for setting up Sentry SDK, configuring alerts, or non-Sentry error monitoring.",
       "category": "monitoring",
       "path": "(monitoring)/sentry",
-      "files": [
-        "LICENSE.txt",
-        "SKILL.md",
-        "scripts/sentry_api.py"
-      ],
+      "files": ["LICENSE.txt", "scripts/sentry_api.py", "SKILL.md"],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
       "contentHash": "aa0e533aff9a319b0aef86ad3e543f61b812bf159c27fc9ebb1c7ad97d5db937"
@@ -1372,9 +1222,7 @@
       "description": "Optimize for search engine visibility and ranking. Use when asked to \"improve SEO\", \"optimize for search\", \"fix meta tags\", \"add structured data\", \"sitemap optimization\", or \"search engine optimization\". Do NOT use for accessibility (use web-accessibility), performance (use core-web-vitals), or comprehensive site audits covering multiple areas (use web-quality-audit).",
       "category": "quality",
       "path": "(quality)/seo",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "web-quality-skills",
       "version": "1.0",
       "contentHash": "fc9897a3923b5e23e00545ac67f4c8c2b6903113bd5f046cda259c98a0f3cd40"
@@ -1385,7 +1233,6 @@
       "category": "development",
       "path": "(development)/shopify-developer",
       "files": [
-        "SKILL.md",
         "references/api-admin.md",
         "references/api-storefront.md",
         "references/app-development.md",
@@ -1396,7 +1243,8 @@
         "references/liquid-objects.md",
         "references/liquid-syntax.md",
         "references/performance.md",
-        "references/theme-development.md"
+        "references/theme-development.md",
+        "SKILL.md"
       ],
       "contentHash": "10dd4806c0061bb9e89914557f6aec6badcef893e601293711ba3e8993527e9f"
     },
@@ -1406,11 +1254,11 @@
       "category": "creation",
       "path": "(creation)/skill-architect",
       "files": [
-        "SKILL.md",
         "references/examples.md",
         "references/patterns.md",
         "references/quality-checklist.md",
-        "scripts/validate_skill.py"
+        "scripts/validate_skill.py",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "1.0.0",
@@ -1421,9 +1269,7 @@
       "description": "\"When the user wants to sell through social media, optimize LinkedIn for sales, build DM sequences, or convert content engagement into pipeline. Also use when the user mentions 'social selling,' 'LinkedIn selling,' 'LinkedIn DMs,' 'social prospecting,' 'LinkedIn Sales Navigator,' 'DM sequences,' 'LinkedIn outreach,' 'social pipeline,' or 'LinkedIn optimization.' This skill covers social selling strategy from profile optimization through DM-to-deal conversion. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/social-selling",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "7cc6fba77aff372c64d8e2b97b2b645ef641ef78a266b602e5e6fdd74231460e"
@@ -1433,9 +1279,7 @@
       "description": "\"When the user is a solo founder building their GTM motion, wants to scale without hiring, or needs to design an AI agent team for go-to-market. Also use when the user mentions 'solo founder,' 'one-person startup,' 'solopreneur,' 'bootstrapped,' 'no team,' 'AI agents as team,' 'scaling without hiring,' 'founder-led sales,' 'lean GTM,' 'one-person company,' or 'no employees.' This skill covers the complete solo founder GTM playbook from stack selection through agent team design, revenue-stage transitions, time allocation, and when to finally hire. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/solo-founder-gtm",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "95d71f10ea8a48767cb871ad72c09745cb6ecd822ed71be659cbd960b6503445"
@@ -1445,11 +1289,7 @@
       "description": "Scores how completely an implementation fulfills a PRD/spec, case by case, and produces a single comparable final grade. Invoke only when explicitly named (e.g. run spec-driven-eval); do not auto-trigger. Use when benchmarking spec-driven implementations, grading acceptance criteria, evaluating whether a feature was 100% implemented, comparing multiple implementations of the same PRD, or auditing implementation and test coverage (unit and e2e) against product requirements. Do NOT use for planning or building features (use tlc-spec-driven), writing PRDs, or general code review unrelated to a spec.",
       "category": "development",
       "path": "(development)/spec-driven-eval",
-      "files": [
-        "SKILL.md",
-        "references/quickstart.md",
-        "references/reference.md"
-      ],
+      "files": ["references/quickstart.md", "references/reference.md", "SKILL.md"],
       "author": "Waldemar Neto - github.com/waldemarnt",
       "version": "1.0.0",
       "contentHash": "168d6860c6e84809a02c2abface032a4a625bdd81fec6131615e00a2cf87e311"
@@ -1459,9 +1299,7 @@
       "description": "Guide for creating AI subagents with isolated context for complex multi-step workflows. Use when users want to create a subagent, specialized agent, verifier, debugger, or orchestrator that requires isolated context and deep specialization. Works with any agent that supports subagent delegation. Triggers on \"create subagent\", \"new agent\", \"specialized assistant\", \"create verifier\". Do NOT use for Cursor-specific subagents (use cursor-subagent-creator instead).",
       "category": "creation",
       "path": "(creation)/subagent-creator",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "contentHash": "bef6b5a9f23b3186af259c1041c2561e9af15fa94810009d72d775bb217aa3ca"
     },
     {
@@ -1469,12 +1307,7 @@
       "description": "Detects anemic domain models, validates and refactors them into rich domain models, and enforces tactical DDD patterns (Entities, Value Objects, Aggregates, Domain Services, Domain Events). Use when the user asks to validate, review, or check domain models or DDD code; detect anemia; refactor domain objects; improve encapsulation; or mentions terms like \"anemic model\", \"rich domain\", \"aggregate\", \"value object\", \"domain event\", \"ubiquitous language\", \"is this good DDD\", \"does this follow DDD\", or \"check my domain\". Do NOT use for module or service boundary design, architectural decomposition, strategic DDD context mapping, or code outside the domain layer (DTOs, controllers, infrastructure adapters).",
       "category": "architecture",
       "path": "(architecture)/tactical-ddd",
-      "files": [
-        "SKILL.md",
-        "detection.md",
-        "refactoring.md",
-        "reference.md"
-      ],
+      "files": ["detection.md", "refactoring.md", "reference.md", "SKILL.md"],
       "contentHash": "c3dfaf45e8cb784f18d9c460c7f005c4ee9dbb430f21ee8af6913bbfea66a75b"
     },
     {
@@ -1482,10 +1315,7 @@
       "description": "Creates comprehensive Technical Design Documents (TDD) with mandatory and optional sections through interactive discovery. Use when user asks to \"write a design doc\", \"create a TDD\", \"technical spec\", \"architecture document\", \"RFC\", \"design proposal\", or needs to document a technical decision before implementation. Do NOT use for README files, API docs, or general documentation (use docs-writer instead).",
       "category": "creation",
       "path": "(creation)/create-technical-design-doc",
-      "files": [
-        "README.md",
-        "SKILL.md"
-      ],
+      "files": ["README.md", "SKILL.md"],
       "contentHash": "d05974df076f695f96b4e4c263ad19f2aaffe8ee6248c1b07a634dd9ed0ea51e"
     },
     {
@@ -1494,18 +1324,38 @@
       "category": "decision-making",
       "path": "(decision-making)/the-fool",
       "files": [
-        "SKILL.md",
         "references/cognitive-bias-inventory.md",
         "references/dialectic-synthesis.md",
         "references/evidence-audit.md",
         "references/mode-selection-guide.md",
         "references/pre-mortem-analysis.md",
         "references/red-team-adversarial.md",
-        "references/socratic-questioning.md"
+        "references/socratic-questioning.md",
+        "SKILL.md"
       ],
       "author": "https://github.com/Jeffallan",
       "version": "2.0.0",
       "contentHash": "b761f983e21e00173ac42760f478095a3e8c733862c20d9f711d10d962f407cc"
+    },
+    {
+      "name": "tlc-generative-engine-optimization",
+      "description": "\"Generative Engine Optimization (GEO) specialist — the technical, on-page publishing work that makes a given page or site discoverable, understandable, trustworthy, quotable, and fresh for AI answer engines (Google AI Overviews, ChatGPT Search, Bing Copilot, Perplexity). Use when asked to 'optimize this page/site for GEO', 'optimize for AI search / answer engines', 'get my page cited by ChatGPT/Perplexity', 'improve AI visibility/citability', 'write an llms.txt', 'add citation-ready structure or schema for AI answers', 'otimizar para busca com IA', or to audit/create/improve a codebase for generative search. Do NOT use for AI-driven SEO content strategy or programmatic pages at scale (use ai-seo), classic keyword/SERP ranking (use seo), accessibility (use web-accessibility), or multi-area site audits (use web-quality-audit).\"",
+      "category": "quality",
+      "path": "(quality)/tlc-generative-engine-optimization",
+      "files": [
+        "references/measurement-and-tools.md",
+        "references/pillars-and-workflow.md",
+        "SKILL.md",
+        "templates/faqpage.jsonld",
+        "templates/llms.txt",
+        "templates/page-metadata.html",
+        "templates/quotable-article-outline.md",
+        "templates/robots-ai-crawlers.txt",
+        "templates/techarticle.jsonld"
+      ],
+      "author": "Fernando Paladini - github.com/paladini",
+      "version": "1.0.0",
+      "contentHash": "dae5b030b1833ad894f5afd3ba0c2026fea73f484bd19bc2f78d7dc8cfe55014"
     },
     {
       "name": "tlc-spec-driven",
@@ -1513,7 +1363,6 @@
       "category": "development",
       "path": "(development)/tlc-spec-driven",
       "files": [
-        "SKILL.md",
         "references/code-analysis.md",
         "references/coding-principles.md",
         "references/context-limits.md",
@@ -1526,7 +1375,8 @@
         "references/sub-agents.md",
         "references/tasks.md",
         "references/validate.md",
-        "scripts/lessons.py"
+        "scripts/lessons.py",
+        "SKILL.md"
       ],
       "author": "Felipe Rodrigues - github.com/felipfr",
       "version": "3.1.0",
@@ -1537,11 +1387,7 @@
       "description": "Deploy applications and websites to Vercel. Use when the user requests deployment actions like \"deploy my app\", \"deploy and give me the link\", \"push this live\", or \"create a preview deployment\". Do NOT use for deploying to Netlify, Cloudflare, or Render (use their respective skills).",
       "category": "cloud",
       "path": "(cloud)/vercel-deploy",
-      "files": [
-        "LICENSE.txt",
-        "SKILL.md",
-        "scripts/deploy.sh"
-      ],
+      "files": ["LICENSE.txt", "scripts/deploy.sh", "SKILL.md"],
       "author": "github.com/openai/skills",
       "version": "1.0.0",
       "contentHash": "53985dad8a6cf5571b8eb796668502f2e82f0574ab15d31609486de8317f0ec5"
@@ -1551,9 +1397,7 @@
       "description": "\"When the user wants to build video-first cold outreach, create personalized video at scale, implement async selling, or use AI demo generation for prospecting. Also use when the user mentions 'video outreach,' 'personalized video,' 'video prospecting,' 'Tavus,' 'Sendspark,' 'HeyGen,' 'video email,' 'async selling,' 'video demo,' or 'made this for you.' This skill covers video-first outreach systems from personalization through conversion optimization. Do NOT use for technical implementation, code review, or software architecture.\"",
       "category": "gtm",
       "path": "(gtm)/video-outreach",
-      "files": [
-        "SKILL.md"
-      ],
+      "files": ["SKILL.md"],
       "author": "Chad Boyda / agent-gtm-skills",
       "version": "1.0.0",
       "contentHash": "b918e2c62adf317b82ac43e4731e300ff4f163383aebe7ae8532f7ea69c24c29"
@@ -1563,10 +1407,7 @@
       "description": "Review UI code for Web Interface Guidelines compliance. Use when asked to \"review my UI\", \"check accessibility\", \"audit design\", \"review UX\", or \"check my site against best practices\". Focuses on visual design and interaction patterns. Do NOT use for performance audits (use core-web-vitals), SEO (use seo), or comprehensive site audits (use web-quality-audit).",
       "category": "design",
       "path": "(design)/web-design-guidelines",
-      "files": [
-        "SKILL.md",
-        "references/guideline.md"
-      ],
+      "files": ["references/guideline.md", "SKILL.md"],
       "author": "vercel",
       "version": "1.0.0",
       "contentHash": "213a23fff251b12ddfec648bda148bf10704ef6617e162eb9329cc83963dd138"
@@ -1576,10 +1417,7 @@
       "description": "Comprehensive web quality audit covering performance, accessibility, SEO, and best practices in a single review. Use when asked to \"audit my site\", \"review web quality\", \"run lighthouse audit\", \"check page quality\", or \"optimize my website\" across multiple areas at once. Orchestrates specialized skills for depth. Do NOT use for single-area audits — prefer core-web-vitals, web-accessibility, seo, or web-best-practices for focused work.",
       "category": "quality",
       "path": "(quality)/web-quality-audit",
-      "files": [
-        "SKILL.md",
-        "scripts/analyze.sh"
-      ],
+      "files": ["scripts/analyze.sh", "SKILL.md"],
       "author": "web-quality-skills",
       "version": "1.0",
       "contentHash": "8af5bd3453984bdcef903709b6ef0606b12ae1badb6dd5b5b382b930d2594d7c"
@@ -1589,44 +1427,32 @@
     {
       "name": "react-native-skills",
       "message": "Use react-native-expert instead",
-      "alternatives": [
-        "react-native-expert"
-      ]
+      "alternatives": ["react-native-expert"]
     },
     {
       "name": "cursor-skill-creator",
       "message": "Use skill-architect instead",
-      "alternatives": [
-        "skill-architect"
-      ]
+      "alternatives": ["skill-architect"]
     },
     {
       "name": "skill-creator",
       "message": "Use skill-architect instead",
-      "alternatives": [
-        "skill-architect"
-      ]
+      "alternatives": ["skill-architect"]
     },
     {
       "name": "run-nx-generator",
       "message": "Use nx-generate instead",
-      "alternatives": [
-        "nx-generate"
-      ]
+      "alternatives": ["nx-generate"]
     },
     {
       "name": "excalidraw-diagram-generator",
       "message": "Use excalidraw-studio instead",
-      "alternatives": [
-        "excalidraw-studio"
-      ]
+      "alternatives": ["excalidraw-studio"]
     },
     {
       "name": "megabrain",
       "message": "megabrain was a temporary name for tlc-spec-driven v3. Use tlc-spec-driven instead.",
-      "alternatives": [
-        "tlc-spec-driven"
-      ]
+      "alternatives": ["tlc-spec-driven"]
     }
   ]
 }

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/SKILL.md
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: tlc-generative-engine-optimization
+description: "Generative Engine Optimization (GEO) specialist — the technical, on-page publishing work that makes a given page or site discoverable, understandable, trustworthy, quotable, and fresh for AI answer engines (Google AI Overviews, ChatGPT Search, Bing Copilot, Perplexity). Use when asked to 'optimize this page/site for GEO', 'optimize for AI search / answer engines', 'get my page cited by ChatGPT/Perplexity', 'improve AI visibility/citability', 'write an llms.txt', 'add citation-ready structure or schema for AI answers', 'otimizar para busca com IA', or to audit/create/improve a codebase for generative search. Do NOT use for AI-driven SEO content strategy or programmatic pages at scale (use ai-seo), classic keyword/SERP ranking (use seo), accessibility (use web-accessibility), or multi-area site audits (use web-quality-audit)."
+metadata:
+  version: '1.0.0'
+  author: Fernando Paladini - github.com/paladini
+license: MIT
+---
+
+# GEO Specialist
+
+Expert in Generative Engine Optimization — making pages discoverable, understandable, trustworthy, quotable, and fresh for AI answer engines.
+
+## Philosophy
+
+Treat GEO as **documentation quality, not a trick**. AI engines cite pages they can parse, trust, and quote. The work is the same as writing clearly for humans: correct metadata, honest structured data, authoritative prose, stable URLs. Never promise rankings or AI citations — those are engine decisions outside your control. Do the technical work well; citations follow as a byproduct.
+
+## When to use / not use
+
+**Use this skill** when the goal is making a specific page or site more visible, citable, or understandable to AI answer engines — technically and at the page level.
+
+**Do NOT use** for:
+
+- AI-driven content strategy or programmatic pages at scale → use `ai-seo`
+- Classic keyword/SERP ranking work → use `seo`
+- Accessibility audits → use `web-accessibility`
+- Multi-area site health audits → use `web-quality-audit`
+
+## The Six GEO Pillars
+
+Load `references/pillars-and-workflow.md` for the full deep-dive. Summary:
+
+| #   | Pillar             | Core check                                                                      |
+| --- | ------------------ | ------------------------------------------------------------------------------- |
+| 1   | **Discoverable**   | robots.txt allows AI crawlers; sitemap exists; canonical tags correct; HTTPS    |
+| 2   | **Understandable** | Semantic HTML; page title matches H1; language declared; one topic per page     |
+| 3   | **Useful**         | Content answers a specific question; content in static HTML (not JS-only)       |
+| 4   | **Trustworthy**    | Author bio; citations/sources linked; publication + update dates visible; HTTPS |
+| 5   | **Quotable**       | One answer per section; short-answer paragraph before elaboration; FAQ schema   |
+| 6   | **Fresh**          | `dateModified` in JSON-LD and meta; content reviewed when topic changes         |
+
+## Operating Modes
+
+### Mode 1 — Create (new GEO-ready page)
+
+1. Plan page structure: one topic, one H1, question-based H2s/H3s.
+2. Apply `templates/page-metadata.html` (canonical, hreflang, meta description).
+3. Add `templates/techarticle.jsonld` (or `faqpage.jsonld` for FAQ pages).
+4. Write content in the quotable outline pattern (`templates/quotable-article-outline.md`): short direct answer → supporting detail → sources.
+5. Update `robots.txt` to allow AI crawlers (`templates/robots-ai-crawlers.txt`).
+6. Add or update `llms.txt` if the site wants to guide AI agents (`templates/llms.txt`).
+7. Run the GEO page checklist (in `references/pillars-and-workflow.md`).
+
+### Mode 2 — Audit (score an existing page or site)
+
+1. Crawl check: read `robots.txt` — are `OAI-SearchBot` and `BingBot` allowed?
+2. Structured data: validate all JSON-LD against the Rich Results Test and Schema Markup Validator.
+3. Pillar sweep: for each of the six pillars, mark pass / partial / fail.
+4. Produce a **prioritized findings table** (Pillar → Finding → Severity → Fix).
+5. Identify quick wins (metadata, schema, robots) vs. content rewrites.
+
+### Mode 3 — Improve (apply fixes)
+
+1. Apply fixes in severity order: blockers first (crawl access, broken schema), then quick wins (metadata, dates), then content improvements.
+2. Re-validate structured data after every schema change.
+3. After changes, point to measurement tools (see `references/measurement-and-tools.md`) so the user can track AI visibility over time.
+
+## Guardrails
+
+- **Never promise** that changes will cause a specific AI engine to cite the page. Citation is an engine decision.
+- **Structured data must match visible page content exactly.** Mismatches violate Google's policies and can suppress the page.
+- **`llms.txt` is optional.** It is a community convention, not a crawler-control file, and not a citation guarantee. Recommend it only when the site wants to guide AI agent navigation.
+- **`robots.txt` is the only authoritative crawler-control file.** `llms.txt` has no effect on crawling.
+- **Do not add `noindex` or `Disallow` for AI crawlers** unless the user explicitly wants to block AI indexing.
+- Prefer primary platform documentation (Google Search Central, Bing Webmaster Tools, Schema.org) over third-party summaries.
+
+## Examples
+
+### Example 1 — Audit request
+
+**User:** "Can you audit my blog for AI search visibility?"
+
+**Actions:**
+
+1. Check `robots.txt` → `OAI-SearchBot` is missing a `Disallow` but also missing an explicit `Allow` — confirm default is allow.
+2. Validate JSON-LD on the homepage → `datePublished` is missing, `author` has no `url`.
+3. Run pillar sweep → Trustworthy: partial (no author bio page); Quotable: fail (no FAQ schema on FAQ page).
+4. Return findings table with three priority tiers.
+
+**Result:** Prioritized list: fix `techarticle.jsonld`, add author bio, add `FAQPage` schema. Clear, actionable, no ranking promises.
+
+### Example 2 — Create request
+
+**User:** "Create a new GEO-optimized article page for my Next.js blog."
+
+**Actions:**
+
+1. Draft `<head>` from `templates/page-metadata.html`.
+2. Generate `templates/techarticle.jsonld` filled with real title, author, dates.
+3. Structure content using `templates/quotable-article-outline.md`: direct-answer intro, H2/H3 sections, sources list.
+4. Confirm `robots.txt` allows `OAI-SearchBot`.
+5. Run checklist — all eight items pass.
+
+**Result:** Ready-to-deploy page with correct metadata, valid schema, and citation-ready prose.
+
+### Example 3 — llms.txt request
+
+**User:** "Write an llms.txt for my documentation site."
+
+**Actions:**
+
+1. Inventory the three or four most useful pages for an AI agent.
+2. Apply `templates/llms.txt` format: H1 site name → blockquote description → `## Key pages` with Markdown links → optional `## Technical files`.
+3. Remind the user that `llms.txt` is not a crawler-control file and doesn't guarantee citations.
+
+**Result:** A concise, standards-compliant `llms.txt` with honest caveats.
+
+## Troubleshooting
+
+| Symptom                                              | Likely cause                                                             | Fix                                                                                    |
+| ---------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Rich Results Test shows no schema                    | JSON-LD is in a JS-rendered `<script>` tag loaded after DOMContentLoaded | Move JSON-LD to a static `<script type="application/ld+json">` in server-rendered HTML |
+| Schema validation error: "required property missing" | `datePublished`, `author`, or `headline` absent                          | Add all required fields; check Schema.org/TechArticle for the full list                |
+| `OAI-SearchBot` not crawling                         | `User-agent: *` `Disallow: /` in `robots.txt` blocks all bots            | Add explicit `Allow: /` for `OAI-SearchBot` above the wildcard rule                    |
+| `llms.txt` not picked up by agents                   | File not at `https://example.com/llms.txt` (must be root)                | Move file to domain root; verify it returns `Content-Type: text/plain`                 |
+| Content visible in browser but not cited             | Content rendered by client-side JS only                                  | Render content server-side so crawlers receive it in the initial HTML response         |
+
+## References and Templates
+
+Load these files on demand — only when the task requires the detail.
+
+| File                                    | Load when                                                                                         |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `references/pillars-and-workflow.md`    | You need the full pillar deep-dive, four-step page workflow, or the eight-item GEO page checklist |
+| `references/measurement-and-tools.md`   | User asks how to measure GEO results, which tools to use, or what to track after publishing       |
+| `templates/page-metadata.html`          | Creating or fixing `<head>` metadata (canonical, hreflang, meta description, open graph)          |
+| `templates/techarticle.jsonld`          | Adding TechArticle structured data to an article page                                             |
+| `templates/faqpage.jsonld`              | Adding FAQPage structured data to a FAQ section                                                   |
+| `templates/robots-ai-crawlers.txt`      | Updating `robots.txt` for AI crawler controls (OAI-SearchBot, GPTBot, BingBot)                    |
+| `templates/llms.txt`                    | Writing or updating the site's `llms.txt`                                                         |
+| `templates/quotable-article-outline.md` | Structuring article content for AI citation                                                       |

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/references/measurement-and-tools.md
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/references/measurement-and-tools.md
@@ -1,0 +1,136 @@
+# GEO Measurement and Tools
+
+**Important caveat up front:** No tool can tell you whether a specific AI engine will cite your page. Citation is an engine decision based on query context, competitive alternatives, and internal quality signals you cannot inspect. These tools measure _inputs_ (crawl access, valid schema, visibility reports) — not guaranteed outputs.
+
+---
+
+## Tool Overview
+
+### 1. Google Search Console (GSC)
+
+**Purpose:** Monitor whether Google can crawl and index your pages; see AI Overviews impressions (when available in your region).
+
+**What to check:**
+
+- Coverage report → confirm pages are indexed, no "Excluded" surprises.
+- URL Inspection → test a specific URL for crawlability and structured data rendering.
+- Performance → look for AI Overview impressions (appears as a separate feature type in some regions).
+
+**Access:** [search.google.com/search-console](https://search.google.com/search-console)
+
+---
+
+### 2. Bing Webmaster Tools
+
+**Purpose:** Monitor Bing indexing; access Bing-specific AI performance reports.
+
+**What to check:**
+
+- Bing AI Performance report — shows impressions from Bing Copilot and Bing AI answers (available in Bing Webmaster Tools under "Reports").
+- Bing AI Visibility Insights — shows which pages appear in Bing AI-generated answers.
+- URL Inspection → confirm BingBot can crawl and render your page.
+
+**Access:** [bing.com/webmasters](https://www.bing.com/webmasters)
+
+---
+
+### 3. Rich Results Test
+
+**Purpose:** Validate JSON-LD structured data in the context of a live URL.
+
+**What to check:**
+
+- Paste a URL → confirm schema type is detected → confirm no errors or warnings.
+- Run after every JSON-LD change before publishing.
+
+**Access:** [search.google.com/test/rich-results](https://search.google.com/test/rich-results)
+
+---
+
+### 4. Schema Markup Validator
+
+**Purpose:** Validate raw JSON-LD snippets against Schema.org types without requiring a live URL.
+
+**Use this for:** Validating schema during development before the page is published.
+
+**Access:** [validator.schema.org](https://validator.schema.org)
+
+---
+
+### 5. IJONIS AI Visibility Checker / geo-lint
+
+**Purpose:** Check whether a page meets common GEO signals (crawl access, structured data presence, content structure).
+
+**What to check:**
+
+- Run geo-lint against your URL to get a pass/fail report per GEO signal.
+- Use as a quick diagnostic, not as a guarantee of citation.
+
+**Access:** [ijonis.com](https://ijonis.com) or via the `geo-lint` CLI if available.
+
+---
+
+### 6. PageSpeed Insights / Lighthouse
+
+**Purpose:** Verify Core Web Vitals and page rendering — slow or JS-only-rendered pages are harder for AI crawlers to process reliably.
+
+**What to check:**
+
+- Run Lighthouse with the "SEO" and "Best Practices" categories.
+- Confirm structured data is detected in the "SEO" section.
+- Confirm no render-blocking scripts prevent content from loading in the initial HTML.
+
+**Access:** [pagespeed.web.dev](https://pagespeed.web.dev)
+
+---
+
+### 7. GoAccess (Server Log Analysis)
+
+**Purpose:** Confirm AI crawlers are actually visiting your pages by reading server access logs.
+
+**What to check:**
+
+- Filter for `OAI-SearchBot`, `GPTBot`, `BingBot`, `PerplexityBot` in access logs.
+- Confirm crawl frequency and which pages are being fetched.
+
+**Use this for:** Verifying that allowing crawlers in `robots.txt` is actually resulting in crawl visits.
+
+---
+
+### 8. promptfoo / OneGlanse (Prompt Monitoring)
+
+**Purpose:** Test whether your page is cited when specific questions are asked to AI answer engines.
+
+**What to check:**
+
+- Set up test prompts that match your page's topic and target queries.
+- Run periodically to see if citations appear and which competitors are cited instead.
+
+**Important:** These tools show current citation behavior — not a guarantee that your changes caused a specific outcome. Citation can change without any action on your part.
+
+---
+
+## Measurement Checklist (6 items)
+
+Run after publishing GEO changes to set up ongoing visibility tracking.
+
+- [ ] **Google Search Console verified** — site is verified; submit updated sitemap.
+- [ ] **Bing Webmaster Tools verified** — site is verified; check AI Performance report baseline.
+- [ ] **Rich Results Test passed** — all JSON-LD on the page shows no errors.
+- [ ] **Crawler visits confirmed** — server logs show at least one crawl from `OAI-SearchBot` or `BingBot` within two weeks of publishing.
+- [ ] **Baseline prompt test recorded** — run 3–5 representative queries in ChatGPT Search and Perplexity; note whether the page is cited (yes/no baseline, not a target).
+- [ ] **Review date set** — schedule a content review for time-sensitive pages (quarterly for most; monthly for pricing/API docs).
+
+---
+
+## What to Expect (Realistic Timelines)
+
+| Signal                  | Typical time to appear after publishing |
+| ----------------------- | --------------------------------------- |
+| Google indexing         | 1 day – 2 weeks                         |
+| Bing indexing           | 1 day – 2 weeks                         |
+| AI Overview appearance  | Weeks to months; not guaranteed         |
+| ChatGPT Search citation | No reliable timeline; engine-controlled |
+| Perplexity citation     | No reliable timeline; engine-controlled |
+
+Changes to robots.txt, structured data, and content quality improve the _conditions_ for citation. They do not schedule it.

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/references/pillars-and-workflow.md
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/references/pillars-and-workflow.md
@@ -1,0 +1,139 @@
+# GEO Pillars, Workflow, and Checklist
+
+## The Six GEO Pillars
+
+GEO = making a page **Discoverable → Understandable → Useful → Trustworthy → Quotable → Fresh** for AI answer engines.
+
+---
+
+### 1. Discoverable
+
+AI engines can only cite pages they can crawl and index.
+
+**Checks:**
+
+- `robots.txt` allows AI search crawlers:
+  - `OAI-SearchBot` — OpenAI's search indexer (controls ChatGPT Search citations)
+  - `GPTBot` — OpenAI's training crawler (separate; can block independently)
+  - `BingBot` — Bing's crawler (used by both Bing Copilot and Bing AI Overviews)
+  - `Googlebot` — Google (used for Google AI Overviews)
+- XML sitemap exists and is linked from `robots.txt` or submitted via Google Search Console / Bing Webmaster Tools.
+- `<link rel="canonical">` is set and matches the preferred URL.
+- Page is served over HTTPS with a valid certificate.
+- No `<meta name="robots" content="noindex">` unless intentionally blocking the page.
+
+**Note:** `OAI-SearchBot` (search indexing) and `GPTBot` (training data) are separately controllable. Many sites block `GPTBot` for training but want to allow `OAI-SearchBot` for search visibility. These are different `User-agent` entries in `robots.txt`.
+
+---
+
+### 2. Understandable
+
+AI engines must parse the page's structure and topic clearly.
+
+**Checks:**
+
+- Semantic HTML: use `<article>`, `<section>`, `<h1>`–`<h3>`, `<p>`, `<ul>` appropriately.
+- Page has exactly one `<h1>` that matches (or closely paraphrases) the `<title>` tag.
+- The `lang` attribute is set on `<html>` (e.g., `lang="en"`).
+- Page covers one focused topic — avoid mixing unrelated subjects.
+- Key content is in static server-rendered HTML, not JavaScript-only rendering.
+
+---
+
+### 3. Useful
+
+Content must answer a specific question or fulfill a specific need.
+
+**Checks:**
+
+- The page answers a clearly defined question a person (or agent) would actually ask.
+- Content is original and substantive — not a thin page duplicating what's already everywhere.
+- The most important answer is in the first `<p>` or the opening of the relevant `<section>`, not buried under navigation or promotional content.
+- All key content is in static HTML; avoid content that only appears after JS execution, login walls, or cookie-consent dismissal.
+
+---
+
+### 4. Trustworthy
+
+AI engines weight pages they can attribute to a credible, verifiable source.
+
+**Checks:**
+
+- Author name is visible on the page and links to an author bio page.
+- Publication date (`datePublished`) and last-modified date (`dateModified`) are visible to readers.
+- Claims are backed by linked sources (outbound links to primary references).
+- Page does not make unsubstantiated superlatives ("the best", "guaranteed", "always").
+- JSON-LD `author`, `publisher`, and date fields are filled with real values — not placeholders.
+
+---
+
+### 5. Quotable
+
+AI answers pull short, self-contained paragraphs. Structure content to be that paragraph.
+
+**Checks:**
+
+- Each H2/H3 section starts with a 1–3 sentence direct answer before elaborating.
+- The direct-answer paragraph is self-contained — it makes sense read in isolation.
+- FAQ sections use `FAQPage` JSON-LD schema so engines can surface individual Q&A pairs.
+- Avoid starting sections with "In this article, we will…" or "As mentioned above…" — these phrases don't stand alone.
+- Lists of steps use numbered `<ol>`; lists of options use `<ul>`. AI engines quote lists accurately.
+
+---
+
+### 6. Fresh
+
+AI engines prefer content that is kept up to date.
+
+**Checks:**
+
+- `dateModified` in JSON-LD is updated whenever the content changes (not just the layout or typos).
+- `<meta property="article:modified_time">` mirrors `dateModified`.
+- A review schedule exists for time-sensitive content (e.g., pricing pages, API docs, compatibility tables).
+- Outdated claims are removed or flagged with the date they were accurate.
+
+---
+
+## Four-Step GEO Page Workflow
+
+Use this sequence when creating or improving a page from scratch.
+
+**Step 1 — Structure**
+
+- Choose a single focused topic.
+- Draft question-based headings (H2s that mirror what a user would type into a search bar).
+- Outline sections: intro answer → supporting detail → examples → sources.
+
+**Step 2 — Write for quotes**
+
+- Open each section with a direct, self-contained answer sentence.
+- Follow with supporting detail and examples.
+- Close with a sources / further-reading list.
+
+**Step 3 — Add signals**
+
+- Apply `page-metadata.html` template (canonical, hreflang, meta description).
+- Add appropriate JSON-LD: `TechArticle` for articles, `FAQPage` for FAQ sections.
+- Check `robots.txt` — confirm AI crawlers are allowed.
+- Add or update `llms.txt` if appropriate.
+
+**Step 4 — Validate and measure**
+
+- Run Rich Results Test on all JSON-LD.
+- Run the GEO Page Checklist below.
+- After publishing, set up measurement (see `measurement-and-tools.md`).
+
+---
+
+## GEO Page Checklist (8 items)
+
+Run before declaring a page GEO-ready.
+
+- [ ] **robots.txt** — `OAI-SearchBot` and `BingBot` are allowed (not blocked by wildcard `Disallow`).
+- [ ] **Canonical** — `<link rel="canonical">` is set and correct.
+- [ ] **Title / H1 alignment** — `<title>` and `<h1>` match or closely paraphrase each other.
+- [ ] **JSON-LD valid** — structured data passes Rich Results Test with no errors; all required fields present.
+- [ ] **Author + dates visible** — author name, `datePublished`, and `dateModified` are readable on the page.
+- [ ] **Static content** — key content is in server-rendered HTML, not JS-only.
+- [ ] **Direct-answer openings** — each H2/H3 section opens with a self-contained answer paragraph.
+- [ ] **Sources linked** — factual claims link to primary sources.

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/faqpage.jsonld
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/faqpage.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "QUESTION_ONE_EXACTLY_AS_VISIBLE_ON_PAGE?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ANSWER_ONE_EXACTLY_AS_VISIBLE_ON_PAGE. Must match visible text — do not add hidden or extra content here."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "QUESTION_TWO_EXACTLY_AS_VISIBLE_ON_PAGE?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ANSWER_TWO_EXACTLY_AS_VISIBLE_ON_PAGE."
+      }
+    }
+  ]
+}

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/llms.txt
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/llms.txt
@@ -1,0 +1,14 @@
+# SITE_NAME
+
+> BRIEF_ONE_OR_TWO_SENTENCE_DESCRIPTION_OF_WHAT_THIS_SITE_OFFERS_AND_WHO_IT_IS_FOR.
+
+## Key pages
+
+- [Page Title](https://example.com/page-path/): One sentence describing what this page covers and what an AI agent would use it for.
+- [Page Title](https://example.com/another-page/): One sentence description.
+- [Page Title](https://example.com/guide/): One sentence description.
+
+## Technical files
+
+- [OpenAPI spec](https://example.com/openapi.json): Machine-readable API definition.
+- [Sitemap](https://example.com/sitemap.xml): Full list of indexed pages.

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/page-metadata.html
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/page-metadata.html
@@ -1,0 +1,33 @@
+<!-- GEO Page Metadata Template
+     Replace ALL_CAPS placeholders with real values.
+     Place inside <head>. -->
+
+<!-- Primary identity -->
+<title>PAGE_TITLE | SITE_NAME</title>
+<meta name="description" content="BRIEF_DESCRIPTION_150_CHARS_MAX" />
+
+<!-- Canonical URL (required — prevents duplicate content signals) -->
+<link rel="canonical" href="https://example.com/page-path/" />
+
+<!-- Language (required for Understandable pillar) -->
+<!-- Remove hreflang block if page has no translations -->
+<link rel="alternate" hreflang="en" href="https://example.com/page-path/" />
+<link rel="alternate" hreflang="pt-BR" href="https://example.com/pt/page-path/" />
+<link rel="alternate" hreflang="x-default" href="https://example.com/page-path/" />
+
+<!-- Open Graph (used by social previews; also read by some AI agents) -->
+<meta property="og:type" content="article" />
+<meta property="og:title" content="PAGE_TITLE" />
+<meta property="og:description" content="BRIEF_DESCRIPTION_150_CHARS_MAX" />
+<meta property="og:url" content="https://example.com/page-path/" />
+<meta property="og:image" content="https://example.com/images/page-og.png" />
+<meta property="og:locale" content="en_US" />
+
+<!-- Article dates (mirrors datePublished/dateModified in JSON-LD) -->
+<meta property="article:published_time" content="YYYY-MM-DDTHH:MM:SSZ" />
+<meta property="article:modified_time" content="YYYY-MM-DDTHH:MM:SSZ" />
+
+<!-- Crawler control (default: allow all) -->
+<!-- Remove or adjust only if you need to restrict specific crawlers. -->
+<!-- To block GPTBot (OpenAI training) but allow OAI-SearchBot (ChatGPT Search): use robots.txt, not meta tags. -->
+<meta name="robots" content="index, follow" />

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/quotable-article-outline.md
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/quotable-article-outline.md
@@ -1,0 +1,59 @@
+# [Article Title: Question or Clear Topic Statement]
+
+[Meta description copy — reuse this as the opening sentence or two of the article. ~150 characters.]
+
+## [Primary Question This Article Answers]
+
+[DIRECT ANSWER — 1–3 sentences. Self-contained: makes sense quoted out of context. This is the paragraph AI engines will quote. Write it before anything else.]
+
+[Supporting detail — 2–4 paragraphs expanding on the direct answer with context, caveats, and examples.]
+
+---
+
+## [Sub-Question or Related Concept 1]
+
+[DIRECT ANSWER — 1–3 sentences, self-contained.]
+
+[Supporting detail.]
+
+- [List item if applicable]
+- [List item if applicable]
+
+---
+
+## [Sub-Question or Related Concept 2]
+
+[DIRECT ANSWER — 1–3 sentences, self-contained.]
+
+[Supporting detail.]
+
+---
+
+## Frequently Asked Questions
+
+### [Question?]
+
+[Direct answer, 1–3 sentences.]
+
+### [Question?]
+
+[Direct answer, 1–3 sentences.]
+
+---
+
+## Sources
+
+- [Source Name](https://primary-source-url.com) — one-sentence description of what this source covers.
+- [Source Name](https://primary-source-url.com) — one-sentence description.
+
+---
+
+<!-- WRITING NOTES (delete before publishing)
+
+Quotable paragraph checklist — for each H2/H3 direct-answer paragraph:
+- Does it answer the heading question directly?
+- Can it be read in isolation and still make sense?
+- Is it under 3 sentences?
+- Does it avoid "In this section, we will..." or "As mentioned above..."?
+
+-->

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/robots-ai-crawlers.txt
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/robots-ai-crawlers.txt
@@ -1,0 +1,53 @@
+# robots.txt — AI crawler controls template
+# Place at: https://example.com/robots.txt
+#
+# KEY DISTINCTION:
+#   OAI-SearchBot = OpenAI's SEARCH INDEXER (controls ChatGPT Search citations)
+#   GPTBot        = OpenAI's TRAINING crawler (controls training data inclusion)
+#   These are separate bots. You can block training without blocking search indexing.
+#
+# OPTION A — Allow all crawlers (default; recommended for most sites wanting GEO visibility)
+
+User-agent: *
+Allow: /
+Sitemap: https://example.com/sitemap.xml
+
+# OPTION B — Allow search crawlers, block training crawlers
+# (Use this if you want ChatGPT Search citations but not training data inclusion)
+
+# User-agent: GPTBot
+# Disallow: /
+
+# User-agent: OAI-SearchBot
+# Allow: /
+
+# User-agent: PerplexityBot
+# Allow: /
+
+# User-agent: BingBot
+# Allow: /
+
+# User-agent: Googlebot
+# Allow: /
+
+# User-agent: *
+# Allow: /
+
+# Sitemap: https://example.com/sitemap.xml
+
+# OPTION C — Block all AI crawlers (use only if you explicitly do NOT want GEO visibility)
+
+# User-agent: GPTBot
+# Disallow: /
+
+# User-agent: OAI-SearchBot
+# Disallow: /
+
+# User-agent: PerplexityBot
+# Disallow: /
+
+# User-agent: CCBot
+# Disallow: /
+
+# User-agent: *
+# Allow: /

--- a/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/techarticle.jsonld
+++ b/packages/skills-catalog/skills/(quality)/tlc-generative-engine-optimization/templates/techarticle.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "PAGE_TITLE_MATCHING_H1",
+  "description": "BRIEF_DESCRIPTION_MATCHING_META_DESCRIPTION",
+  "datePublished": "YYYY-MM-DD",
+  "dateModified": "YYYY-MM-DD",
+  "author": {
+    "@type": "Person",
+    "name": "AUTHOR_FULL_NAME",
+    "url": "https://example.com/about/author-name/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "SITE_OR_COMPANY_NAME",
+    "url": "https://example.com",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/images/logo.png"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/page-path/"
+  },
+  "image": "https://example.com/images/page-og.png",
+  "articleSection": "TOPIC_CATEGORY",
+  "inLanguage": "en"
+}


### PR DESCRIPTION
## Summary

- Adds `tlc-generative-engine-optimization` to the `(quality)` category — a GEO specialist for the technical, on-page publishing work that makes pages discoverable, understandable, trustworthy, quotable, and fresh for AI answer engines (Google AI Overviews, ChatGPT Search, Bing Copilot, Perplexity)
- Includes `SKILL.md`, two `references/` docs, and six `templates/` artifacts ready to copy into any project
- Validator: **23 checks passed, 0 warnings, 0 failures** (`npm run validate`)
- Registry regenerated: 82 skills total

## Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Main skill — philosophy, 6 pillars table, 3 modes (Create/Audit/Improve), guardrails, examples, troubleshooting |
| `references/pillars-and-workflow.md` | Full pillar deep-dive + 4-step page workflow + 8-item GEO checklist |
| `references/measurement-and-tools.md` | 8 measurement tools with honest no-guarantees caveats |
| `templates/page-metadata.html` | Canonical, hreflang, Open Graph `<head>` template |
| `templates/techarticle.jsonld` | TechArticle JSON-LD structured data |
| `templates/faqpage.jsonld` | FAQPage JSON-LD structured data |
| `templates/robots-ai-crawlers.txt` | robots.txt with OAI-SearchBot vs GPTBot distinction |
| `templates/llms.txt` | Site guide for AI agents |
| `templates/quotable-article-outline.md` | Citation-ready article structure |

## Test plan

- [x] `npm run validate` — 82/82 skills pass; tlc-generative-engine-optimization: 23 checks, 0 warnings
- [x] `npm run generate:registry` — 82 skills, 15 categories, no errors
- [x] `npm run format` — Prettier applied, no issues
- [ ] Trigger test — "optimize this page for AI search" should route here, not to `seo` or `ai-seo`
