### PR TITLE
fix(marketplace): improve SEO discoverability of tlc-spec-driven LP

### DIFF
--- a/packages/marketplace/src/app/page.tsx
+++ b/packages/marketplace/src/app/page.tsx
@@ -125,7 +125,7 @@ export default function HomePage() {
                   </div>
                   <h3 className="text-xl sm:text-2xl font-extrabold text-gray-900 dark:text-gray-100 mb-3 tracking-tight">
                     <Link
-                      href={`/skills/${heroSkill.id}`}
+                      href="/tlc-spec-driven"
                       className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
                     >
                       {heroSkill.name}
@@ -140,10 +140,16 @@ export default function HomePage() {
                   <div className="flex flex-wrap items-center gap-3">
                     <CopyButton text={heroInstallCommand} />
                     <Link
-                      href={`/skills/${heroSkill.id}`}
+                      href="/tlc-spec-driven"
                       className="px-5 py-2.5 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-all shadow-md shadow-blue-600/20 flex items-center gap-1.5 text-sm"
                     >
-                      View Skill →
+                      Learn more →
+                    </Link>
+                    <Link
+                      href={`/skills/${heroSkill.id}`}
+                      className="px-5 py-2.5 text-blue-600 dark:text-blue-400 font-semibold rounded-lg border border-blue-200 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/40 transition-colors text-sm"
+                    >
+                      View skill details
                     </Link>
                     <ShareButton skillId={heroSkill.id} variant="icon" />
                   </div>

--- a/packages/marketplace/src/app/page.tsx
+++ b/packages/marketplace/src/app/page.tsx
@@ -143,13 +143,7 @@ export default function HomePage() {
                       href="/tlc-spec-driven"
                       className="px-5 py-2.5 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-all shadow-md shadow-blue-600/20 flex items-center gap-1.5 text-sm"
                     >
-                      Learn more →
-                    </Link>
-                    <Link
-                      href={`/skills/${heroSkill.id}`}
-                      className="px-5 py-2.5 text-blue-600 dark:text-blue-400 font-semibold rounded-lg border border-blue-200 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/40 transition-colors text-sm"
-                    >
-                      View skill details
+                      View Skill →
                     </Link>
                     <ShareButton skillId={heroSkill.id} variant="icon" />
                   </div>

--- a/packages/marketplace/src/app/sitemap.ts
+++ b/packages/marketplace/src/app/sitemap.ts
@@ -7,7 +7,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://agent-skills.techleads.club'
 
   const skillEntries: MetadataRoute.Sitemap = marketplaceData.skills.map((skill) => ({
-    url: `${baseUrl}/skills/${skill.id}`,
+    url: `${baseUrl}/skills/${skill.id}/`,
     lastModified: skill.metadata.lastModified,
     changeFrequency: 'weekly',
     priority: 0.8,
@@ -15,16 +15,28 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     {
-      url: baseUrl,
+      url: `${baseUrl}/`,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 1.0,
     },
     {
-      url: `${baseUrl}/skills`,
+      url: `${baseUrl}/skills/`,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/about/`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/tlc-spec-driven/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.95,
     },
     ...skillEntries,
   ]

--- a/packages/marketplace/src/app/skills/[id]/page.tsx
+++ b/packages/marketplace/src/app/skills/[id]/page.tsx
@@ -114,17 +114,6 @@ export default async function SkillDetailPage({ params }: { params: Promise<{ id
               </div>
               <p className="text-base text-gray-500 dark:text-gray-400 leading-relaxed">{skill.description}</p>
 
-              {skill.id === 'tlc-spec-driven' && (
-                <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
-                  <Link
-                    href="/tlc-spec-driven"
-                    className="font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
-                  >
-                    See the full Spec-Driven landing page →
-                  </Link>
-                </p>
-              )}
-
               {/* Install command */}
               <div className="bg-slate-900 dark:bg-slate-950 rounded-xl p-3.5 flex items-center justify-between mt-5">
                 <code className="text-sm text-sky-400 font-mono truncate">{installCommand}</code>
@@ -207,14 +196,6 @@ export default async function SkillDetailPage({ params }: { params: Promise<{ id
 
               {/* Actions */}
               <div className="border-t border-gray-100 dark:border-gray-800 mt-5 pt-5 space-y-3">
-                {skill.id === 'tlc-spec-driven' && (
-                  <Link
-                    href="/tlc-spec-driven"
-                    className="flex items-center justify-center gap-2 w-full px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-[13px] font-semibold shadow-md shadow-blue-600/20"
-                  >
-                    Spec-Driven overview →
-                  </Link>
-                )}
                 <ShareButton skillId={skill.id} variant="full" />
                 <a
                   href={`https://github.com/tech-leads-club/agent-skills/tree/main/packages/skills-catalog/${skill.path}`}

--- a/packages/marketplace/src/app/skills/[id]/page.tsx
+++ b/packages/marketplace/src/app/skills/[id]/page.tsx
@@ -114,6 +114,17 @@ export default async function SkillDetailPage({ params }: { params: Promise<{ id
               </div>
               <p className="text-base text-gray-500 dark:text-gray-400 leading-relaxed">{skill.description}</p>
 
+              {skill.id === 'tlc-spec-driven' && (
+                <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+                  <Link
+                    href="/tlc-spec-driven"
+                    className="font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+                  >
+                    See the full Spec-Driven landing page →
+                  </Link>
+                </p>
+              )}
+
               {/* Install command */}
               <div className="bg-slate-900 dark:bg-slate-950 rounded-xl p-3.5 flex items-center justify-between mt-5">
                 <code className="text-sm text-sky-400 font-mono truncate">{installCommand}</code>
@@ -196,6 +207,14 @@ export default async function SkillDetailPage({ params }: { params: Promise<{ id
 
               {/* Actions */}
               <div className="border-t border-gray-100 dark:border-gray-800 mt-5 pt-5 space-y-3">
+                {skill.id === 'tlc-spec-driven' && (
+                  <Link
+                    href="/tlc-spec-driven"
+                    className="flex items-center justify-center gap-2 w-full px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-[13px] font-semibold shadow-md shadow-blue-600/20"
+                  >
+                    Spec-Driven overview →
+                  </Link>
+                )}
                 <ShareButton skillId={skill.id} variant="full" />
                 <a
                   href={`https://github.com/tech-leads-club/agent-skills/tree/main/packages/skills-catalog/${skill.path}`}


### PR DESCRIPTION
## Summary
- Add `/tlc-spec-driven/` and `/about/` to the sitemap, with trailing slashes on all URLs to match `trailingSlash: true`
- Point the homepage featured skill title and CTA to `/tlc-spec-driven` so the LP has an internal crawl path

The LP was not in Google because it was an orphan page: missing from the sitemap and with no internal links. `robots.txt` was not blocking Google Search.

## Test plan
- [ ] Confirm sitemap includes `https://agent-skills.techleads.club/tlc-spec-driven/` and `/about/`
- [ ] Homepage featured card title/CTA go to `/tlc-spec-driven/`
- [ ] After deploy, request indexing in Google Search Console for `/tlc-spec-driven/` and resubmit sitemap