### PR TITLE
fix(release): migrate release tag config to the Nx 23 shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ out
 
 # Specs
 .specs
+
+# Nx local artifacts
+.nx/cache
+.nx/polygraph
+.nx/self-healing
+.nx/migrate-runs

--- a/nx.json
+++ b/nx.json
@@ -37,15 +37,21 @@
     "groups": {
       "cli": {
         "projects": ["@tech-leads-club/agent-skills"],
-        "releaseTagPattern": "v{version}"
+        "releaseTag": {
+          "pattern": "v{version}"
+        }
       },
       "skills-catalog": {
         "projects": ["@tech-leads-club/skills-catalog"],
-        "releaseTagPattern": "skills-catalog-v{version}"
+        "releaseTag": {
+          "pattern": "skills-catalog-v{version}"
+        }
       },
       "mcp": {
         "projects": ["@tech-leads-club/agent-skills-mcp"],
-        "releaseTagPattern": "mcp-v{version}"
+        "releaseTag": {
+          "pattern": "mcp-v{version}"
+        }
       }
     },
     "git": {
@@ -69,7 +75,12 @@
         "refactor": {
           "semverBump": "patch"
         },
-        "chore": { "semverBump": "patch", "changelog": { "hidden": true } },
+        "chore": {
+          "semverBump": "patch",
+          "changelog": {
+            "hidden": true
+          }
+        },
         "test": false,
         "style": false,
         "build": false,


### PR DESCRIPTION
The release workflow has been failing on `main` since the Nx 23 upgrade, before it does any work:

```
NX  Found deprecated releaseTagPattern* properties in your nx.json that are
    no longer supported in Nx 23.

The following properties were moved to the nested "releaseTag" object in Nx 22
and removed in Nx 23:
  - release.groups.cli.releaseTagPattern
  - release.groups.skills-catalog.releaseTagPattern
  - release.groups.mcp.releaseTagPattern
```

## Cause

Nx 22 moved the flat `releaseTagPattern` property into a nested `releaseTag` object, and Nx 23 removed the flat form outright. The toolchain was bumped to Nx 23 without running the accompanying migrations, so `nx release` now exits 1 during config validation — no version is computed, nothing is published.

## Fix

Per-group `releaseTagPattern` becomes `releaseTag.pattern`:

```diff
   "cli": {
     "projects": ["@tech-leads-club/agent-skills"],
-    "releaseTagPattern": "v{version}"
+    "releaseTag": {
+      "pattern": "v{version}"
+    }
   },
```

Same for `skills-catalog` and `mcp`.

> **`nx repair` does not fix this.** Its `23-0-0-consolidate-release-tag-config` migration runs and reports *"No changes were made"* — it only handles the property at the root of `release`, not inside `release.groups`. These three were migrated by hand. Worth knowing if anyone hits a similar deprecation notice and expects `repair` to be enough.

## Verification

Dry run, confirming tags resolve exactly as before and the publish step completes:

```
@tech-leads-club/agent-skills     🏷️ Resolved the current version as 1.4.9 from git tag "v1.4.9",
                                     based on releaseTag.pattern "v{version}"
                                  ❓ Applied semver relative bump "patch" → 1.4.10

@tech-leads-club/agent-skills-mcp 🏷️ Resolved the current version as 0.1.5 from git tag "mcp-v0.1.5",
                                     based on releaseTag.pattern "mcp-v{version}"
                                  ❓ Applied semver relative bump "patch" → 0.1.6

NX  Successfully ran target nx-release-publish for project @tech-leads-club/agent-skills-mcp
```

No deprecation notice, and the tag patterns are unchanged — this is a config shape migration, not a behaviour change.

`npx nx run-many -t lint test --all` → 5 projects, 476 tests, green.

## Also

Gitignores the Nx local artifact directories the upgrade introduced: `.nx/polygraph`, `.nx/self-healing`, `.nx/migrate-runs`.

`nx repair` additionally wanted to reformat every `project.json` (arrays onto one line, key reordering) and to add `.claude/` entries to `.gitignore`. Both were reverted — the reformatting is noise in an unrelated diff, and the editor-specific ignores are the team's call, not a side effect of a release fix.
