### PR TITLE
feat(harness-eval): clearer Track B/C agreement reports

### DIFF
--- a/packages/skills-catalog/CHANGELOG.md
+++ b/packages/skills-catalog/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Actionable bands (Ship, Hold, Slim, fan-in blocked, Mixed) now lead with a **summary table**, then a **Details** section with per-item cards (`In` / `You should`).
 - Review (Track B) and Keep-core (Track C) stay **table-only** for quick scanning.
 - Report headers use a **relative** run path (`.harness-eval/runs/<id>`), not an absolute filesystem path.
-- Hold reasons are human-readable (e.g. `judges disagreed` instead of `disagree`).
+- Hold reasons show **code + label** for humans and agents (e.g. `` `disagree` — judges disagreed ``); trap misses use `MISSING` instead of `None`; tier breakdowns are markdown (`T1 **2**`) not Python dict repr; `Bands:` blockquotes list all Hold reason codes.
 
 **What did NOT change**
 

--- a/packages/skills-catalog/CHANGELOG.md
+++ b/packages/skills-catalog/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 ### 🚀 Features
 
-- **harness-eval:** clarify Track B `07-agreement.md` and Track C `10-usefulness-agreement.md` — summary table plus Details cards (In/You should); no absolute paths. Same section order and merge JSON as before
+- **harness-eval:** clearer Track B `07-agreement.md` and Track C `10-usefulness-agreement.md` (skill **1.8.3 → 1.8.4**)
+
+**What you'll notice**
+
+- Actionable bands (Ship, Hold, Slim, fan-in blocked, Mixed) now lead with a **summary table**, then a **Details** section with per-item cards (`In` / `You should`).
+- Review (Track B) and Keep-core (Track C) stay **table-only** for quick scanning.
+- Report headers use a **relative** run path (`.harness-eval/runs/<id>`), not an absolute filesystem path.
+- Hold reasons are human-readable (e.g. `judges disagreed` instead of `disagree`).
+
+**What did NOT change**
+
+- Same section order and band names (Ship / Review / Hold; Slim / Keep-core / Mixed / Hold).
+- Same merge script stdout JSON (`ship`, `review`, `hold`, etc.) and the same judge score inputs (`05`/`06`, `08`/`09`).
+- Existing run directories are not modified until you re-run the merge scripts.
+
+**If you have an old run**
+
+- Re-run only `merge_agreement.py` and/or `merge_usefulness.py` on the existing `--run-dir` — no need to re-judge claims or surfaces.
 
 ## 0.17.4 (2026-08-28)
 

--- a/packages/skills-catalog/CHANGELOG.md
+++ b/packages/skills-catalog/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.17.5 (2026-08-31)
+
+### 🚀 Features
+
+- **harness-eval:** clarify Track B `07-agreement.md` and Track C `10-usefulness-agreement.md` — summary table plus Details cards (In/You should); no absolute paths. Same section order and merge JSON as before
+
 ## 0.17.4 (2026-08-28)
 
 ### 🚀 Features

--- a/packages/skills-catalog/skills-registry.json
+++ b/packages/skills-catalog/skills-registry.json
@@ -898,7 +898,7 @@
       ],
       "author": "Tech Leads Club - github.com/tech-leads-club",
       "version": "1.8.4",
-      "contentHash": "ce29b5836b5d27be1c1b32fbacd319bb3c98130f5008a9077192c479c6eb40fb"
+      "contentHash": "8237db9c985a37b131a6bdea5ad844dc5a7d839a68e87c6cf2c549aaf44276cd"
     },
     {
       "name": "jira-assistant",

--- a/packages/skills-catalog/skills-registry.json
+++ b/packages/skills-catalog/skills-registry.json
@@ -897,8 +897,8 @@
         "scripts/track_a_correctness.py"
       ],
       "author": "Tech Leads Club - github.com/tech-leads-club",
-      "version": "1.8.3",
-      "contentHash": "675761f3fdb123f26103811ffe52e384adff5ffdf7c603578dfaa4eb2e54b2a2"
+      "version": "1.8.4",
+      "contentHash": "6efc84ea78a7a37563fe56f446de97c9d50c75cdf55973f50e27b5e2fd32f017"
     },
     {
       "name": "jira-assistant",

--- a/packages/skills-catalog/skills-registry.json
+++ b/packages/skills-catalog/skills-registry.json
@@ -898,7 +898,7 @@
       ],
       "author": "Tech Leads Club - github.com/tech-leads-club",
       "version": "1.8.4",
-      "contentHash": "6efc84ea78a7a37563fe56f446de97c9d50c75cdf55973f50e27b5e2fd32f017"
+      "contentHash": "ce29b5836b5d27be1c1b32fbacd319bb3c98130f5008a9077192c479c6eb40fb"
     },
     {
       "name": "jira-assistant",

--- a/packages/skills-catalog/skills/(development)/harness-eval/SKILL.md
+++ b/packages/skills-catalog/skills/(development)/harness-eval/SKILL.md
@@ -4,7 +4,7 @@ description: "Evaluate a repo agent harness (AGENTS.md, rules, skills, skill ref
 license: CC-BY-4.0
 metadata:
   author: Tech Leads Club - github.com/tech-leads-club
-  version: 1.8.3
+  version: 1.8.4
 ---
 
 # Harness Eval
@@ -163,7 +163,7 @@ Prefer Steps 4 and 5 in parallel.
 python3 "$SKILL_DIR/scripts/merge_agreement.py" --run-dir .harness-eval/runs/$RUN_ID
 ```
 
-Expected: `07-agreement.md` (Ship/Review/Hold + **What these words mean**). On trap FAIL: fix plants per PROTOCOL, rescore P00x, re-merge — do not Ship.
+Expected: `07-agreement.md` (summary table + Details cards with In / You should per Ship/Hold; Review table; **What these words mean**). On trap FAIL: fix plants per PROTOCOL, rescore P00x, re-merge — do not Ship.
 
 ### Step 7: Track C — surface deck
 
@@ -193,7 +193,7 @@ Prefer Steps 8 and 9 in parallel.
 python3 "$SKILL_DIR/scripts/merge_usefulness.py" --run-dir .harness-eval/runs/$RUN_ID
 ```
 
-Expected: `10-usefulness-agreement.md` (Slim/Keep-core/Mixed/Hold + **What these words mean**), `11-mixed-apply.md` (KEEP/CUT per Mixed ID), plus `slim-fanin.json`. On trap FAIL: do not Slim. Surfaces with `slim-fanin-blocked` are Hold — not Slim apply candidates.
+Expected: `10-usefulness-agreement.md` (summary table + Details cards per Slim/fan-in/Mixed/Hold; Keep-core table; **What these words mean**), `11-mixed-apply.md` (KEEP/CUT per Mixed ID), plus `slim-fanin.json`. On trap FAIL: do not Slim. Surfaces with `slim-fanin-blocked` are Hold — not Slim apply candidates.
 
 ### Step 11: Present results
 
@@ -204,12 +204,12 @@ Summarize from the agreement reports (each starts with term definitions):
 - Track C trap + fan-in + Slim/Keep-core/Mixed/Hold → `10-usefulness-agreement.md`
 - Call out `11-mixed-apply.md` when Mixed count > 0 (the only Mixed apply path)
 - Call out model ids used for Track C and that Slim is model-sensitive
-- Call out any **Slim fan-in blocked** rows (consumers outside seed may appear here)
+- Call out any **Slim fan-in blocked** cards (consumers outside seed may appear here)
 
 Stop unless the user asks to apply Ship/Slim/Mixed. When applying:
 
-- **Slim:** only paths in the Slim table (fan-in PASS); never stub fan-in-blocked paths without updating citers first.
-- **Mixed:** open `11-mixed-apply.md` and execute KEEP/CUT per ID only (rule 12). Never re-judge from the Mixed path list alone. Never add code-tree path pointers as substitutes for cut demos (rule 11).
+- **Slim:** only paths in the Slim band (fan-in PASS); never stub fan-in-blocked paths without updating citers first.
+- **Mixed:** open `11-mixed-apply.md` and execute KEEP/CUT per ID only (rule 12). Never re-judge from the Mixed band alone. Never add code-tree path pointers as substitutes for cut demos (rule 11).
 
 ## Examples
 
@@ -249,7 +249,7 @@ Expected: usefulness is model-sensitive. Re-run C1+C2 on a second model; interse
 
 ### Mixed apply rewrote conventions / removed modules
 
-Cause: apply agent re-judged from the Mixed path list instead of following KEEP/CUT. Solution: apply only via `11-mixed-apply.md`; if that file is missing, re-run `merge_usefulness.py`; if Keep-core/Slim cells are vague, re-score those IDs before apply.
+Cause: apply agent re-judged from the Mixed band instead of following KEEP/CUT. Solution: apply only via `11-mixed-apply.md`; if that file is missing, re-run `merge_usefulness.py`; if Keep-core/Slim cells are vague, re-score those IDs before apply.
 
 ### T2 empty / skill `references/` missing from inventory
 

--- a/packages/skills-catalog/skills/(development)/harness-eval/references/PROTOCOL.md
+++ b/packages/skills-catalog/skills/(development)/harness-eval/references/PROTOCOL.md
@@ -1,6 +1,6 @@
 # Harness Evaluation Protocol
 
-> Platform- and codebase-agnostic. Version: 1.8.3
+> Platform- and codebase-agnostic. Version: 1.8.4
 > Scripts and this file live inside the `harness-eval` skill. Run outputs go to the target repo under `.harness-eval/runs/<id>/`.
 
 ## Purpose
@@ -167,7 +167,7 @@ python3 "$SKILL_DIR/scripts/merge_usefulness.py" --run-dir .harness-eval/runs/$R
 | **B** | Medium — dual LLM + plants; trap gate; disagree → Hold | High — 2 × every claim |
 | **C** | Lowest / model-sensitive — dual LLM + plants + fan-in | Highest — 2 × every surface (whole files) |
 
-Human-facing reports: `04-correctness.md`, `07-agreement.md`, `10-usefulness-agreement.md` — each starts with **What these words mean**. Mixed apply plan: `11-mixed-apply.md`. Full glossary: skill `references/GLOSSARY.md`.
+Human-facing reports: `04-correctness.md`, `07-agreement.md`, `10-usefulness-agreement.md` — each starts with **What these words mean**. Track B/C bands lead with a **summary table**, then **Details** cards (`In` / `You should`) for actionable rows. Mixed apply plan: `11-mixed-apply.md`. Full glossary: skill `references/GLOSSARY.md`.
 
 ## Safety
 
@@ -175,6 +175,6 @@ Evidence-or-zero for BROKEN, REDUNDANT, and SLIM/THEORY; author ≠ blind judges
 
 **Slim apply:** never stub/delete a path in the Slim band if `10-usefulness-agreement.md` lists it under fan-in blocked, or if a fresh `slim_fanin.py --path <P>` reports citers — update consumers in the same change first.
 
-**Mixed apply:** follow `11-mixed-apply.md` only (KEEP/CUT per ID). Do not re-judge from the Mixed path table in `10`. KEEP contracts must survive as in-skill rules/snippets; CUT is the only removable bulk.
+**Mixed apply:** follow `11-mixed-apply.md` only (KEEP/CUT per ID). Do not re-judge from the Mixed band in `10`. KEEP contracts must survive as in-skill rules/snippets; CUT is the only removable bulk.
 
 **Mixed/Slim apply (self-contained):** When cutting REPO-DEMONSTRATED, THEORY, or OVERLAP bulk, leave the remaining BEHAVIOR-CHANGING text self-contained in the harness surface. Never replace a fenced teaching snippet (or the contract it carried) with a soft/hard pointer into `app/`, `lib/`, `test/`, or other non-harness trees. Paths cited in usefulness Evidence / REPO-DEMONSTRATED tags are for judges only.

--- a/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_agreement.py
+++ b/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_agreement.py
@@ -16,6 +16,12 @@ ROW_RE = re.compile(
 REDUNDANT = {"REDUNDANT-CODE", "REDUNDANT-GENERAL"}
 KEEP = {"KEEP-POLICY", "KEEP-CAVEAT", "KEEP-ROUTING", "KEEP-COMPRESSED", "UNCLEAR"}
 
+HOLD_TITLES = {
+    "missing-score": "a judge did not score this",
+    "disagree": "judges disagreed",
+    "trap-fail-discard-ship": "trap gate failed — Ship discarded",
+}
+
 
 def family(cls: str) -> str:
     if cls in REDUNDANT:
@@ -44,6 +50,54 @@ def load_claims(path: Path) -> dict[str, dict]:
             row = json.loads(line)
             rows[row["id"]] = row
     return rows
+
+
+def display_run_dir(run: Path) -> str:
+    posix = run.as_posix().replace("\\", "/")
+    marker = ".harness-eval/"
+    idx = posix.lower().find(marker)
+    if idx >= 0:
+        return posix[idx:]
+    return run.name
+
+
+def format_misses(misses: list[dict]) -> str:
+    if not misses:
+        return "none"
+    return ", ".join(
+        f"{m['id']} (expected {m['expected']}, got {m['got']})" for m in misses
+    )
+
+
+def clip_quote(claim: dict, limit: int = 280) -> str:
+    q = (claim.get("quote") or "").replace("\n", " ").strip()
+    if len(q) > limit:
+        return q[: limit - 1] + "…"
+    return q
+
+
+def j1_cell(score: dict | None) -> str:
+    return f"`{score['class']}`" if score else "—"
+
+
+def j2_cell(score: dict | None) -> str:
+    if not score:
+        return "—"
+    return f"cost {score['cost']} / `{score['class']}`"
+
+
+def j2_table(score: dict | None) -> str:
+    if not score:
+        return "—"
+    return f"{score['cost']}/{score['class']}"
+
+
+def table_quote(claim: dict, limit: int = 80) -> str:
+    return clip_quote(claim, limit).replace("|", "\\|")
+
+
+def hold_reason_label(reason: str) -> str:
+    return HOLD_TITLES.get(reason, reason.replace("-", " "))
 
 
 def main() -> int:
@@ -91,7 +145,7 @@ def main() -> int:
     lines = [
         "# Harness Eval: Judge Agreement (Track B)",
         "",
-        f"> Run dir: `{run}`",
+        f"> Run dir: `{display_run_dir(run)}`",
         f"> Trap gate: {'PASS' if trap_pass else 'FAIL'} (misses={len(misses)})",
         "> Bands: Ship = dual REDUNDANT + J2 cost≤1; Review = dual KEEP; Hold = disagree / missing",
         "",
@@ -103,6 +157,7 @@ def main() -> int:
         "| **Review** | Both judges: keep (not redundant) | Leave alone |",
         "| **Hold** | Judges disagreed or score missing | Do nothing yet |",
         "| **Trap PASS** | Planted traps scored correctly | Trust Ship |",
+        "| **T0 / T1 / T2** | Always-on rules / skills / cited harness refs | Fix T0 cites first (always loaded) |",
         "",
         "This track answers: *would an agent rediscover this without the harness?* "
         "Not the same as usefulness (`10-usefulness-agreement.md`).",
@@ -113,7 +168,7 @@ def main() -> int:
         f"- Ship: **{len(ship)}**",
         f"- Review: **{len(review)}**",
         f"- Hold: **{len(hold)}**",
-        f"- Trap misses: {misses or 'none'}",
+        f"- Trap misses: {format_misses(misses)}",
         "",
         "## Discrimination (plants)",
         "",
@@ -131,33 +186,100 @@ def main() -> int:
         "",
         "## Ship",
         "",
-        "| ID | Tier | Source | J1 | J2 cost/class | Quote |",
-        "|----|------|--------|----|---------------|-------|",
+        "Safe to delete or trim — both judges say an agent would rediscover this cheaply from the repo.",
+        "",
     ]
-    for cid, claim, a, b in ship:
-        q = claim["quote"][:120].replace("|", "\\|")
-        lines.append(
-            f"| {cid} | {claim['tier']} | `{claim['source']}` | {a['class']} | {b['cost']}/{b['class']} | {q} |"
-        )
-
-    lines += ["", "## Hold", "", "| ID | Tier | Reason | J1 | J2 | Quote |", "|----|------|--------|----|----|-------|"]
-    for cid, claim, a, b, reason in hold:
-        q = claim["quote"][:100].replace("|", "\\|")
-        a_s = a["class"] if a else "—"
-        b_s = f"{b['cost']}/{b['class']}" if b else "—"
-        lines.append(f"| {cid} | {claim['tier']} | {reason} | {a_s} | {b_s} | {q} |")
+    if not ship:
+        lines.append("_No Ship claims._")
+        lines.append("")
+    else:
+        lines += [
+            "| ID | Tier | Source | J1 | J2 cost/class | Quote |",
+            "|----|------|--------|----|---------------|-------|",
+        ]
+        for cid, claim, a, b in ship:
+            lines.append(
+                f"| {cid} | {claim['tier']} | `{claim['source']}` | {a['class']} | "
+                f"{j2_table(b)} | {table_quote(claim)} |"
+            )
+        lines += ["", "### Details", ""]
+        for cid, claim, a, b in ship:
+            lines += [
+                f"#### [{cid}] Ship — safe to trim",
+                "",
+                f"- **In:** `{claim['source']}`",
+                f"- **The instruction says:** \"{clip_quote(claim)}\"",
+                f"- **Judges:** both say this is obvious from the repo "
+                f"(J1 {j1_cell(a)}, J2 {j2_cell(b)})",
+                "- **You should:** Delete or trim this sentence.",
+                "",
+            ]
 
     lines += [
+        "## Hold",
         "",
+        "Judges disagreed, a score is missing, or the trap gate failed — do nothing yet.",
+        "",
+    ]
+    if not hold:
+        lines.append("_No Hold claims._")
+        lines.append("")
+    else:
+        lines += [
+            "| ID | Tier | Reason | Source | J1 | J2 cost/class | Quote |",
+            "|----|------|--------|--------|----|---------------|-------|",
+        ]
+        for cid, claim, a, b, reason in hold:
+            a_s = a["class"] if a else "—"
+            lines.append(
+                f"| {cid} | {claim['tier']} | {hold_reason_label(reason)} | "
+                f"`{claim['source']}` | {a_s} | {j2_table(b)} | {table_quote(claim)} |"
+            )
+        lines += ["", "### Details", ""]
+        for cid, claim, a, b, reason in hold:
+            title = hold_reason_label(reason)
+            lines += [
+                f"#### [{cid}] Hold — {title}",
+                "",
+                f"- **In:** `{claim['source']}`",
+                f"- **The instruction says:** \"{clip_quote(claim)}\"",
+                f"- **Judges:** J1 {j1_cell(a)} vs J2 {j2_cell(b)}",
+                "- **You should:** Do nothing yet.",
+                "",
+            ]
+
+    lines += [
         "## Review (KEEP family)",
         "",
-        f"{len(review)} claims. See J1/J2 score tables for detail.",
+        "Both judges: keep (not redundant). Leave these sentences alone.",
         "",
+    ]
+    if not review:
+        lines.append("_No Review claims._")
+        lines.append("")
+    else:
+        lines += [
+            "| ID | Tier | Source | J1 | J2 cost/class | Quote |",
+            "|----|------|--------|----|---------------|-------|",
+        ]
+        for cid, claim, a, b in review:
+            lines.append(
+                f"| {cid} | {claim['tier']} | `{claim['source']}` | {a['class']} | "
+                f"{j2_table(b)} | {table_quote(claim)} |"
+            )
+        lines.append("")
+        lines.append(
+            f"{len(review)} claims. See J1/J2 score tables "
+            "(`05-redundancy-j1.md`, `06-blind-scores.md`) for full rows."
+        )
+        lines.append("")
+
+    lines += [
         "## Action guidance",
         "",
-        "- **T0 Ship:** edit always-on rules now.",
-        "- **T1 Ship:** skill cleanup backlog.",
-        "- **T2 Ship:** routing/pointer hygiene.",
+        "- **T0 Ship:** always-on rules (always loaded) — edit now.",
+        "- **T1 Ship:** skills — cleanup backlog.",
+        "- **T2 Ship:** cited harness refs — routing/pointer hygiene.",
         "- **Hold:** do not trim.",
         "",
     ]

--- a/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_agreement.py
+++ b/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_agreement.py
@@ -159,8 +159,7 @@ def main() -> int:
         "| **Trap PASS** | Planted traps scored correctly | Trust Ship |",
         "| **T0 / T1 / T2** | Always-on rules / skills / cited harness refs | Fix T0 cites first (always loaded) |",
         "",
-        "This track answers: *would an agent rediscover this without the harness?* "
-        "Not the same as usefulness (`10-usefulness-agreement.md`).",
+        "This track answers: *would an agent rediscover this without the harness?* Not the same as usefulness (`10-usefulness-agreement.md`).",
         "",
         "## Executive summary",
         "",
@@ -209,8 +208,7 @@ def main() -> int:
                 "",
                 f"- **In:** `{claim['source']}`",
                 f"- **The instruction says:** \"{clip_quote(claim)}\"",
-                f"- **Judges:** both say this is obvious from the repo "
-                f"(J1 {j1_cell(a)}, J2 {j2_cell(b)})",
+                f"- **Judges:** both say this is obvious from the repo (J1 {j1_cell(a)}, J2 {j2_cell(b)})",
                 "- **You should:** Delete or trim this sentence.",
                 "",
             ]
@@ -269,8 +267,7 @@ def main() -> int:
             )
         lines.append("")
         lines.append(
-            f"{len(review)} claims. See J1/J2 score tables "
-            "(`05-redundancy-j1.md`, `06-blind-scores.md`) for full rows."
+            f"{len(review)} claims. See J1/J2 score tables (`05-redundancy-j1.md`, `06-blind-scores.md`) for full rows."
         )
         lines.append("")
 

--- a/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_agreement.py
+++ b/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_agreement.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 ROW_RE = re.compile(
@@ -64,9 +65,27 @@ def display_run_dir(run: Path) -> str:
 def format_misses(misses: list[dict]) -> str:
     if not misses:
         return "none"
+
+    def got_label(g: object) -> str:
+        return "MISSING" if g is None else str(g)
+
     return ", ".join(
-        f"{m['id']} (expected {m['expected']}, got {m['got']})" for m in misses
+        f"{m['id']} (expected {m['expected']}, got {got_label(m['got'])})" for m in misses
     )
+
+
+def format_tier_breakdown(items: list, tiers: tuple[str, ...] = ("T0", "T1", "T2")) -> str:
+    counts = Counter(c[1]["tier"] for c in items)
+    parts = [f"{t} **{counts[t]}**" for t in tiers if counts.get(t, 0)]
+    return ", ".join(parts) if parts else "_(none)_"
+
+
+def format_hold_reason(reason: str) -> str:
+    return f"`{reason}` — {hold_reason_label(reason)}"
+
+
+def hold_codes_list() -> str:
+    return " / ".join(HOLD_TITLES.keys())
 
 
 def clip_quote(claim: dict, limit: int = 280) -> str:
@@ -137,17 +156,14 @@ def main() -> int:
         else:
             review.append((cid, claim, a, b))
 
-    from collections import Counter
-
-    def tier_bucket(items):
-        return dict(Counter(c[1]["tier"] for c in items))
-
     lines = [
         "# Harness Eval: Judge Agreement (Track B)",
         "",
+        "> harness-eval-report: track=B schema=1",
         f"> Run dir: `{display_run_dir(run)}`",
         f"> Trap gate: {'PASS' if trap_pass else 'FAIL'} (misses={len(misses)})",
-        "> Bands: Ship = dual REDUNDANT + J2 cost≤1; Review = dual KEEP; Hold = disagree / missing",
+        "> Bands: Ship = dual REDUNDANT + J2 cost≤1 + trap PASS; Review = dual KEEP; "
+        f"Hold = {hold_codes_list()}",
         "",
         "## What these words mean",
         "",
@@ -180,8 +196,8 @@ def main() -> int:
 
     lines += [
         "",
-        f"Ship by tier: {tier_bucket(ship)}",
-        f"Hold by tier: {tier_bucket(hold)}",
+        f"Ship by tier: {format_tier_breakdown(ship)}",
+        f"Hold by tier: {format_tier_breakdown(hold)}",
         "",
         "## Ship",
         "",
@@ -230,7 +246,7 @@ def main() -> int:
         for cid, claim, a, b, reason in hold:
             a_s = a["class"] if a else "—"
             lines.append(
-                f"| {cid} | {claim['tier']} | {hold_reason_label(reason)} | "
+                f"| {cid} | {claim['tier']} | {format_hold_reason(reason)} | "
                 f"`{claim['source']}` | {a_s} | {j2_table(b)} | {table_quote(claim)} |"
             )
         lines += ["", "### Details", ""]
@@ -239,6 +255,7 @@ def main() -> int:
             lines += [
                 f"#### [{cid}] Hold — {title}",
                 "",
+                f"- **Reason:** {format_hold_reason(reason)}",
                 f"- **In:** `{claim['source']}`",
                 f"- **The instruction says:** \"{clip_quote(claim)}\"",
                 f"- **Judges:** J1 {j1_cell(a)} vs J2 {j2_cell(b)}",

--- a/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
+++ b/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
@@ -43,6 +43,15 @@ SLIM_FAMILY = {"SLIM", "ROUTING-ONLY"}
 KEEP_FAMILY = {"KEEP-CORE"}
 MIXED_FAMILY = {"MIXED"}
 
+HOLD_TITLES = {
+    "missing-score": "a judge did not score this",
+    "disagree": "judges disagreed",
+    "both-unclear": "both judges were unclear",
+    "slim-fanin-blocked": "fan-in blocked",
+    "trap-fail-discard-slim": "trap gate failed — Slim discarded",
+    "other": "not classified",
+}
+
 
 def family(overall: str) -> str:
     o = overall.upper().strip()
@@ -99,6 +108,43 @@ def load_surfaces(path: Path) -> dict[str, dict]:
     return {s["id"]: s for s in data.get("surfaces", [])}
 
 
+def display_run_dir(run: Path) -> str:
+    posix = run.as_posix().replace("\\", "/")
+    marker = ".harness-eval/"
+    idx = posix.lower().find(marker)
+    if idx >= 0:
+        return posix[idx:]
+    return run.name
+
+
+def format_misses(misses: list[dict]) -> str:
+    if not misses:
+        return "none"
+    return ", ".join(
+        f"{m['id']} (expected {m['expected']}, got {m['got']})" for m in misses
+    )
+
+
+def overall_cell(score: dict | None) -> str:
+    return f"`{score['overall']}`" if score else "—"
+
+
+def overall_table(score: dict | None) -> str:
+    return score["overall"] if score else "—"
+
+
+def hold_reason_label(reason: str) -> str:
+    return HOLD_TITLES.get(reason, reason.replace("-", " "))
+
+
+def citer_list(hits: list[dict], limit: int = 8) -> str:
+    unique = list(dict.fromkeys(h["citer"] for h in hits))
+    citers = ", ".join(f"`{c}`" for c in unique[:limit])
+    if len(unique) > limit:
+        citers += f" (+{len(unique) - limit} more)"
+    return citers or "none"
+
+
 def cell_or_missing(score: dict | None, key: str, *, required_for_apply: bool = False) -> str:
     if not score:
         return "_(missing score)_"
@@ -120,7 +166,7 @@ def write_mixed_apply(
     lines = [
         "# Mixed apply plan (Track C)",
         "",
-        f"> Run dir: `{run}`",
+        f"> Run dir: `{display_run_dir(run)}`",
         f"> Judges: J1 model=`{m1 or 'unrecorded'}` · J2 model=`{m2 or 'unrecorded'}`",
         "> **This file is the only Mixed apply input.** Do not re-judge usefulness.",
         "",
@@ -254,7 +300,7 @@ def main() -> int:
     lines = [
         "# Harness Eval: Usefulness Agreement (Track C)",
         "",
-        f"> Run dir: `{run}`",
+        f"> Run dir: `{display_run_dir(run)}`",
         f"> Trap gate: {'PASS' if trap_pass else 'FAIL'} (misses={len(misses)})",
         f"> Fan-in gate: {'PASS' if not fanin_blocked else 'BLOCKED'} "
         f"(slim-fanin-blocked={len(fanin_blocked)})",
@@ -264,7 +310,7 @@ def main() -> int:
         "Hold = disagree / unclear / missing / slim-fanin-blocked",
         "> **Model-sensitive:** re-judge on a second model before large Slim deletes.",
         "> **Fan-in:** another harness surface hard-loads this path as SoT → Hold, not Slim.",
-        "> **Mixed apply:** use `11-mixed-apply.md` only — do not re-judge from this table alone.",
+        "> **Mixed apply:** use `11-mixed-apply.md` only — do not re-judge from this band alone.",
         "",
         "## What these words mean",
         "",
@@ -277,6 +323,7 @@ def main() -> int:
         "| **Hold** | Judges disagreed, unclear, or Slim blocked by fan-in | Do nothing yet (or update consumers first) |",
         "| **Trap PASS** | Planted traps scored correctly | Necessary but not sufficient for Slim |",
         "| **Fan-in blocked** | Another harness file mandates loading this path / treats it as SoT | Do **not** stub/delete until consumers are updated |",
+        "| **T0 / T1 / T2** | Always-on rules / skills / cited harness refs | Fix T0 cites first (always loaded) |",
         "",
         "This track answers: *does deleting this change agent behavior?* "
         "Not the same as redundancy (`07-agreement.md`).",
@@ -288,7 +335,7 @@ def main() -> int:
         f"- Keep-core: **{len(keep)}**",
         f"- Mixed: **{len(mixed)}** → apply plan: `11-mixed-apply.md`",
         f"- Hold: **{len(hold)}** (fan-in blocked: {len(fanin_blocked)})",
-        f"- Trap misses: {misses or 'none'}",
+        f"- Trap misses: {format_misses(misses)}",
         "",
         "## Discrimination (plants)",
         "",
@@ -306,78 +353,158 @@ def main() -> int:
         f"Mixed by tier: {tier_bucket(mixed)}",
         f"Hold by tier: {tier_bucket(hold)}",
         "",
-        "## Slim (compress / delete body candidates)",
+        "## Slim",
         "",
-        "| ID | Tier | Name | Path | J1 | J2 |",
-        "|----|------|------|------|----|----|",
+        "Mostly theory, demo, or overlap — compress or delete the file body after you approve.",
+        "",
     ]
-    for sid, surf, a, b in slim:
-        lines.append(
-            f"| {sid} | {surf['tier']} | {surf['name']} | `{surf['path']}` | {a['overall']} | {b['overall']} |"
-        )
+    if not slim:
+        lines.append("_No Slim candidates._")
+        lines.append("")
+    else:
+        lines += [
+            "| ID | Tier | Name | Path | J1 | J2 |",
+            "|----|------|------|------|----|----|",
+        ]
+        for sid, surf, a, b in slim:
+            lines.append(
+                f"| {sid} | {surf['tier']} | {surf['name']} | `{surf['path']}` | "
+                f"{overall_table(a)} | {overall_table(b)} |"
+            )
+        lines += ["", "### Details", ""]
+        for sid, surf, a, b in slim:
+            lines += [
+                f"#### [{sid}] Slim — compress or delete body",
+                "",
+                f"- **In:** `{surf['path']}`",
+                f"- **Judges:** J1 {overall_cell(a)} · J2 {overall_cell(b)}",
+                "- **You should:** Compress or delete this file body (after you approve). "
+                "Do not slim if this path appears under fan-in blocked.",
+                "",
+            ]
 
     lines += [
-        "",
         "## Slim fan-in blocked (do not stub/delete)",
         "",
         "Dual SLIM/ROUTING-ONLY, but another harness surface hard-loads the path "
         "(load/SoT/extract mandate). Update or drop those consumers before Slim apply.",
         "",
-        "| ID | Path | Citers |",
-        "|----|------|--------|",
     ]
-    if fanin_blocked:
-        for sid, surf, _a, _b, hits in fanin_blocked:
-            unique = list(dict.fromkeys(h["citer"] for h in hits))
-            citers = ", ".join(f"`{c}`" for c in unique[:8])
-            if len(unique) > 8:
-                citers += f" (+{len(unique) - 8} more)"
-            lines.append(f"| {sid} | `{surf['path']}` | {citers} |")
+    if not fanin_blocked:
+        lines.append("_No fan-in blocked paths._")
+        lines.append("")
     else:
-        lines.append("| — | — | none |")
+        lines += [
+            "| ID | Tier | Name | Path | J1 | J2 | Citers |",
+            "|----|------|------|------|----|----|--------|",
+        ]
+        for sid, surf, a, b, hits in fanin_blocked:
+            citers = citer_list(hits, limit=3)
+            lines.append(
+                f"| {sid} | {surf['tier']} | {surf['name']} | `{surf['path']}` | "
+                f"{overall_table(a)} | {overall_table(b)} | {citers} |"
+            )
+        lines += ["", "### Details", ""]
+        for sid, surf, a, b, hits in fanin_blocked:
+            lines += [
+                f"#### [{sid}] Slim — fan-in blocked",
+                "",
+                f"- **In:** `{surf['path']}`",
+                f"- **Judges:** J1 {overall_cell(a)} · J2 {overall_cell(b)}",
+                f"- **Looked for consumers:** {citer_list(hits)}",
+                "- **You should:** Do not stub/delete until those files are updated.",
+                "",
+            ]
 
     lines += [
-        "",
         "## Keep-core",
         "",
-        "| ID | Tier | Name | Path | J1 | J2 |",
-        "|----|------|------|------|----|----|",
+        "Do not slim these files — most of the file changes agent behavior.",
+        "",
     ]
-    for sid, surf, a, b in keep:
-        lines.append(
-            f"| {sid} | {surf['tier']} | {surf['name']} | `{surf['path']}` | {a['overall']} | {b['overall']} |"
-        )
+    if not keep:
+        lines.append("_No Keep-core surfaces._")
+        lines.append("")
+    else:
+        lines += [
+            "| ID | Tier | Name | Path | J1 | J2 |",
+            "|----|------|------|------|----|----|",
+        ]
+        for sid, surf, a, b in keep:
+            lines.append(
+                f"| {sid} | {surf['tier']} | {surf['name']} | `{surf['path']}` | "
+                f"{overall_table(a)} | {overall_table(b)} |"
+            )
+        lines.append("")
 
     lines += [
-        "",
         "## Mixed (keep core, slim examples/theory)",
         "",
-        "Path list only. **Apply instructions:** `11-mixed-apply.md` (KEEP/CUT per ID).",
+        "Real rules plus large theory/examples/overlap. "
+        "**Apply instructions:** `11-mixed-apply.md` (KEEP/CUT per ID).",
         "",
-        "| ID | Tier | Name | Path | J1 | J2 |",
-        "|----|------|------|------|----|----|",
     ]
-    for sid, surf, a, b in mixed:
-        lines.append(
-            f"| {sid} | {surf['tier']} | {surf['name']} | `{surf['path']}` | {a['overall']} | {b['overall']} |"
-        )
+    if not mixed:
+        lines.append("_No Mixed surfaces._")
+        lines.append("")
+    else:
+        lines += [
+            "| ID | Tier | Name | Path | J1 | J2 |",
+            "|----|------|------|------|----|----|",
+        ]
+        for sid, surf, a, b in mixed:
+            lines.append(
+                f"| {sid} | {surf['tier']} | {surf['name']} | `{surf['path']}` | "
+                f"{overall_table(a)} | {overall_table(b)} |"
+            )
+        lines += ["", "### Details", ""]
+        for sid, surf, a, b in mixed:
+            lines += [
+                f"#### [{sid}] Mixed — keep rules, cut bulk",
+                "",
+                f"- **In:** `{surf['path']}`",
+                f"- **Judges:** J1 {overall_cell(a)} · J2 {overall_cell(b)}",
+                "- **You should:** Open `11-mixed-apply.md` and follow KEEP/CUT for this path.",
+                "",
+            ]
 
     lines += [
-        "",
         "## Hold",
         "",
-        "| ID | Tier | Reason | J1 | J2 | Path |",
-        "|----|------|--------|----|----|------|",
+        "Judges disagreed, were unclear, a score is missing, or Slim is blocked by fan-in.",
+        "",
     ]
-    for sid, surf, a, b, reason in hold:
-        a_s = a["overall"] if a else "—"
-        b_s = b["overall"] if b else "—"
-        lines.append(
-            f"| {sid} | {surf['tier']} | {reason} | {a_s} | {b_s} | `{surf['path']}` |"
-        )
+    if not hold:
+        lines.append("_No Hold surfaces._")
+        lines.append("")
+    else:
+        lines += [
+            "| ID | Tier | Reason | Name | Path | J1 | J2 |",
+            "|----|------|--------|------|------|----|----|",
+        ]
+        for sid, surf, a, b, reason in hold:
+            lines.append(
+                f"| {sid} | {surf['tier']} | {hold_reason_label(reason)} | {surf['name']} | "
+                f"`{surf['path']}` | {overall_table(a)} | {overall_table(b)} |"
+            )
+        lines += ["", "### Details", ""]
+        for sid, surf, a, b, reason in hold:
+            title = hold_reason_label(reason)
+            hold_action = (
+                "Do nothing yet (or update consumers first)."
+                if reason == "slim-fanin-blocked"
+                else "Do nothing yet."
+            )
+            lines += [
+                f"#### [{sid}] Hold — {title}",
+                "",
+                f"- **In:** `{surf['path']}`",
+                f"- **Judges:** J1 {overall_cell(a)} vs J2 {overall_cell(b)}",
+                f"- **You should:** {hold_action}",
+                "",
+            ]
 
     lines += [
-        "",
         "## Action guidance",
         "",
         "- **Slim:** compress only after trap PASS **and** fan-in PASS; still human-approve; "

--- a/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
+++ b/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
@@ -302,12 +302,9 @@ def main() -> int:
         "",
         f"> Run dir: `{display_run_dir(run)}`",
         f"> Trap gate: {'PASS' if trap_pass else 'FAIL'} (misses={len(misses)})",
-        f"> Fan-in gate: {'PASS' if not fanin_blocked else 'BLOCKED'} "
-        f"(slim-fanin-blocked={len(fanin_blocked)})",
+        f"> Fan-in gate: {'PASS' if not fanin_blocked else 'BLOCKED'} (slim-fanin-blocked={len(fanin_blocked)})",
         f"> Judges: J1 model=`{m1 or 'unrecorded'}` · J2 model=`{m2 or 'unrecorded'}`",
-        "> Bands: Slim = dual SLIM/ROUTING + trap PASS + fan-in PASS; "
-        "Keep-core = dual KEEP-CORE; Mixed = dual MIXED; "
-        "Hold = disagree / unclear / missing / slim-fanin-blocked",
+        "> Bands: Slim = dual SLIM/ROUTING + trap PASS + fan-in PASS; Keep-core = dual KEEP-CORE; Mixed = dual MIXED; Hold = disagree / unclear / missing / slim-fanin-blocked",
         "> **Model-sensitive:** re-judge on a second model before large Slim deletes.",
         "> **Fan-in:** another harness surface hard-loads this path as SoT → Hold, not Slim.",
         "> **Mixed apply:** use `11-mixed-apply.md` only — do not re-judge from this band alone.",
@@ -317,16 +314,14 @@ def main() -> int:
         "| Word | Meaning | You should |",
         "|------|---------|------------|",
         "| **Keep-core** | Most of the file changes agent behavior | Do **not** slim |",
-        "| **Mixed** | Real rules + large theory/examples/overlap | Keep rules; cut bulk — "
-        "follow `11-mixed-apply.md` |",
+        "| **Mixed** | Real rules + large theory/examples/overlap | Keep rules; cut bulk — follow `11-mixed-apply.md` |",
         "| **Slim** | Mostly theory / repo-demo / overlap, **and** no other harness surface hard-loads it | Compress or delete body |",
         "| **Hold** | Judges disagreed, unclear, or Slim blocked by fan-in | Do nothing yet (or update consumers first) |",
         "| **Trap PASS** | Planted traps scored correctly | Necessary but not sufficient for Slim |",
         "| **Fan-in blocked** | Another harness file mandates loading this path / treats it as SoT | Do **not** stub/delete until consumers are updated |",
         "| **T0 / T1 / T2** | Always-on rules / skills / cited harness refs | Fix T0 cites first (always loaded) |",
         "",
-        "This track answers: *does deleting this change agent behavior?* "
-        "Not the same as redundancy (`07-agreement.md`).",
+        "This track answers: *does deleting this change agent behavior?* Not the same as redundancy (`07-agreement.md`).",
         "",
         "## Executive summary",
         "",
@@ -378,16 +373,14 @@ def main() -> int:
                 "",
                 f"- **In:** `{surf['path']}`",
                 f"- **Judges:** J1 {overall_cell(a)} · J2 {overall_cell(b)}",
-                "- **You should:** Compress or delete this file body (after you approve). "
-                "Do not slim if this path appears under fan-in blocked.",
+                "- **You should:** Compress or delete this file body (after you approve). Do not slim if this path appears under fan-in blocked.",
                 "",
             ]
 
     lines += [
         "## Slim fan-in blocked (do not stub/delete)",
         "",
-        "Dual SLIM/ROUTING-ONLY, but another harness surface hard-loads the path "
-        "(load/SoT/extract mandate). Update or drop those consumers before Slim apply.",
+        "Dual SLIM/ROUTING-ONLY, but another harness surface hard-loads the path (load/SoT/extract mandate). Update or drop those consumers before Slim apply.",
         "",
     ]
     if not fanin_blocked:
@@ -440,8 +433,7 @@ def main() -> int:
     lines += [
         "## Mixed (keep core, slim examples/theory)",
         "",
-        "Real rules plus large theory/examples/overlap. "
-        "**Apply instructions:** `11-mixed-apply.md` (KEEP/CUT per ID).",
+        "Real rules plus large theory/examples/overlap. **Apply instructions:** `11-mixed-apply.md` (KEEP/CUT per ID).",
         "",
     ]
     if not mixed:
@@ -507,13 +499,9 @@ def main() -> int:
     lines += [
         "## Action guidance",
         "",
-        "- **Slim:** compress only after trap PASS **and** fan-in PASS; still human-approve; "
-        "prefer re-judge on a second model if deleting >30% of a skill.",
-        "- **Slim fan-in blocked:** do **not** stub/delete; either keep the checklist body or "
-        "update every citing harness surface in the same change, then re-merge.",
-        "- **Mixed:** open `11-mixed-apply.md` and execute KEEP/CUT per ID only. "
-        "Do **not** re-judge. Do **not** replace KEEP snippets with `See app/...` or defer "
-        "KEEP contracts to AGENTS.md. Empty Keep-core/Slim cells → skip that path.",
+        "- **Slim:** compress only after trap PASS **and** fan-in PASS; still human-approve; prefer re-judge on a second model if deleting >30% of a skill.",
+        "- **Slim fan-in blocked:** do **not** stub/delete; either keep the checklist body or update every citing harness surface in the same change, then re-merge.",
+        "- **Mixed:** open `11-mixed-apply.md` and execute KEEP/CUT per ID only. Do **not** re-judge. Do **not** replace KEEP snippets with `See app/...` or defer KEEP contracts to AGENTS.md. Empty Keep-core/Slim cells → skip that path.",
         "- **Keep-core:** do not slim for usefulness reasons.",
         "- **Hold:** no usefulness trim.",
         "- See `08-usefulness-j1.md` / `09-usefulness-j2.md` for raw score rows.",
@@ -563,4 +551,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    sys.exit(main())
+
     sys.exit(main())

--- a/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
+++ b/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
@@ -120,9 +120,27 @@ def display_run_dir(run: Path) -> str:
 def format_misses(misses: list[dict]) -> str:
     if not misses:
         return "none"
+
+    def got_label(g: object) -> str:
+        return "MISSING" if g is None else str(g)
+
     return ", ".join(
-        f"{m['id']} (expected {m['expected']}, got {m['got']})" for m in misses
+        f"{m['id']} (expected {m['expected']}, got {got_label(m['got'])})" for m in misses
     )
+
+
+def format_tier_breakdown(items: list, tiers: tuple[str, ...] = ("T0", "T1", "T2")) -> str:
+    counts = Counter(c[1]["tier"] for c in items)
+    parts = [f"{t} **{counts[t]}**" for t in tiers if counts.get(t, 0)]
+    return ", ".join(parts) if parts else "_(none)_"
+
+
+def format_hold_reason(reason: str) -> str:
+    return f"`{reason}` — {hold_reason_label(reason)}"
+
+
+def hold_codes_list() -> str:
+    return " / ".join(HOLD_TITLES.keys())
 
 
 def overall_cell(score: dict | None) -> str:
@@ -292,19 +310,19 @@ def main() -> int:
         else:
             hold.append((sid, surf, a, b, "other"))
 
-    def tier_bucket(items):
-        return dict(Counter(c[1]["tier"] for c in items))
-
     mixed_apply_path = write_mixed_apply(run, mixed, m1, m2)
 
     lines = [
         "# Harness Eval: Usefulness Agreement (Track C)",
         "",
+        "> harness-eval-report: track=C schema=1",
         f"> Run dir: `{display_run_dir(run)}`",
         f"> Trap gate: {'PASS' if trap_pass else 'FAIL'} (misses={len(misses)})",
         f"> Fan-in gate: {'PASS' if not fanin_blocked else 'BLOCKED'} (slim-fanin-blocked={len(fanin_blocked)})",
         f"> Judges: J1 model=`{m1 or 'unrecorded'}` · J2 model=`{m2 or 'unrecorded'}`",
-        "> Bands: Slim = dual SLIM/ROUTING + trap PASS + fan-in PASS; Keep-core = dual KEEP-CORE; Mixed = dual MIXED; Hold = disagree / unclear / missing / slim-fanin-blocked",
+        "> Bands: Slim = dual SLIM/ROUTING + trap PASS + fan-in PASS; Keep-core = dual KEEP-CORE; "
+        "Mixed = dual MIXED; "
+        f"Hold = {hold_codes_list()}",
         "> **Model-sensitive:** re-judge on a second model before large Slim deletes.",
         "> **Fan-in:** another harness surface hard-loads this path as SoT → Hold, not Slim.",
         "> **Mixed apply:** use `11-mixed-apply.md` only — do not re-judge from this band alone.",
@@ -343,10 +361,10 @@ def main() -> int:
 
     lines += [
         "",
-        f"Slim by tier: {tier_bucket(slim)}",
-        f"Keep-core by tier: {tier_bucket(keep)}",
-        f"Mixed by tier: {tier_bucket(mixed)}",
-        f"Hold by tier: {tier_bucket(hold)}",
+        f"Slim by tier: {format_tier_breakdown(slim)}",
+        f"Keep-core by tier: {format_tier_breakdown(keep)}",
+        f"Mixed by tier: {format_tier_breakdown(mixed)}",
+        f"Hold by tier: {format_tier_breakdown(hold)}",
         "",
         "## Slim",
         "",
@@ -476,7 +494,7 @@ def main() -> int:
         ]
         for sid, surf, a, b, reason in hold:
             lines.append(
-                f"| {sid} | {surf['tier']} | {hold_reason_label(reason)} | {surf['name']} | "
+                f"| {sid} | {surf['tier']} | {format_hold_reason(reason)} | {surf['name']} | "
                 f"`{surf['path']}` | {overall_table(a)} | {overall_table(b)} |"
             )
         lines += ["", "### Details", ""]
@@ -490,6 +508,7 @@ def main() -> int:
             lines += [
                 f"#### [{sid}] Hold — {title}",
                 "",
+                f"- **Reason:** {format_hold_reason(reason)}",
                 f"- **In:** `{surf['path']}`",
                 f"- **Judges:** J1 {overall_cell(a)} vs J2 {overall_cell(b)}",
                 f"- **You should:** {hold_action}",

--- a/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
+++ b/packages/skills-catalog/skills/(development)/harness-eval/scripts/merge_usefulness.py
@@ -552,5 +552,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-
-    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Track B (`07-agreement.md`)** and **Track C (`10-usefulness-agreement.md`)** follow the same human-readable pattern as Track A: glossary at top, **summary table per band**, then **Details** cards (`In` / `You should`) for actionable rows (Ship, Hold, Slim, fan-in blocked, Mixed).
- **Relative run paths** in report headers (`.harness-eval/runs/<id>`).
- **Hold reasons: code + label** — e.g. `` `disagree` — judges disagreed `` (stable token for agents, prose for humans).
- **Output polish (no logic change):** trap misses show `MISSING` not `None`; tier breakdowns are markdown (`T1 **2**`); `Bands:` blockquotes list all Hold reason codes; `harness-eval-report: track=B|C schema=1` metadata line.
- **Review (B)** and **Keep-core (C)** stay table-only; **Mixed apply** (`11-mixed-apply.md`) unchanged except relative run dir.
- **Merge logic unchanged:** same band membership, stdout JSON keys, judge score parsing.
- Skill **1.8.4**, skills-catalog **0.17.5** (contentHash refreshed).

Companion to merged Track A DevEx ([#175](https://github.com/tech-leads-club/agent-skills/pull/175) / [#174](https://github.com/tech-leads-club/agent-skills/issues/174)).

## For users

**What you will notice**

- Actionable bands: **summary table** first, then **Details** cards with `In` / `You should`.
- Hold Reason column and cards: `` `code` — human label ``.
- Executive summary tier lines read naturally (no Python `dict` repr).
- `Run dir` is relative, not an absolute filesystem path.

**What did NOT change**

- Same section order and band names.
- Same merge script stdout JSON and judge inputs (`05`/`06`, `08`/`09`).
- Old run dirs untouched until you re-run merge scripts.

**If you have an old run**

Re-run only `merge_agreement.py` and/or `merge_usefulness.py` on the existing `--run-dir` — no need to re-judge.

## Test plan

- [x] Smoke merge on b-smoke / c-smoke: hybrid markdown, relative paths, JSON counts unchanged
- [x] harness-score `--seed AGENTS.md` and re-merge `2026-08-19-full`: band counts unchanged (ship=6, review=62, hold=3)
- [x] CodeQL / implicit string concat fixes in merge scripts
- [x] contentHash recomputed without `__pycache__` artifacts
- [x] Ready for human review