### PR TITLE
fix(marketplace): busca de skills que realmente encontra

### DIFF
--- a/packages/marketplace/src/app/skills/SkillsClient.tsx
+++ b/packages/marketplace/src/app/skills/SkillsClient.tsx
@@ -5,7 +5,8 @@ import { CategoryFilter } from '../../components/CategoryFilter'
 import { Pagination } from '../../components/Pagination'
 import { SearchBar } from '../../components/SearchBar'
 import { SkillCard } from '../../components/SkillCard'
-import { filterAndSortSkills, paginateSkills, type SkillSortOption } from '../../lib/skills-filter'
+import { filterAndSortSkillsWithMeta, paginateSkills, type SkillSortOption } from '../../lib/skills-filter'
+import { buildSearchIndex } from '../../lib/skills-search'
 import type { MarketplaceData } from '../../types'
 
 interface SkillsClientProps {
@@ -40,15 +41,20 @@ export function SkillsClient({ data }: SkillsClientProps) {
     setUrlReady(true)
   }, [])
 
-  const filteredSkills = useMemo(
+  // why: normalizing 92 skill bodies on every keystroke would stall typing, so the index is
+  // built once per dataset and reused by each query.
+  const searchIndex = useMemo(() => buildSearchIndex(data.skills, data.categories), [data.skills, data.categories])
+
+  const { skills: filteredSkills, fullMatchCount } = useMemo(
     () =>
-      filterAndSortSkills({
+      filterAndSortSkillsWithMeta({
         skills: data.skills,
         searchQuery,
         selectedCategory,
         sortBy,
+        searchIndex,
       }),
-    [data.skills, searchQuery, selectedCategory, sortBy],
+    [data.skills, searchQuery, selectedCategory, sortBy, searchIndex],
   )
 
   useEffect(() => {
@@ -76,6 +82,21 @@ export function SkillsClient({ data }: SkillsClientProps) {
   const endIndex = startIndex + PAGE_SIZE
   const paginatedSkills = paginateSkills(filteredSkills, currentPage, PAGE_SIZE)
 
+  // why: only the relevance ordering groups full matches first, so the "related" divider is
+  // meaningless (and would land in the wrong place) under an explicit name/recent sort.
+  const grouped = searchQuery.trim() !== '' && sortBy === 'featured'
+  const exactOnPage = grouped ? paginatedSkills.slice(0, Math.max(0, fullMatchCount - startIndex)) : paginatedSkills
+  const relatedOnPage = grouped ? paginatedSkills.slice(exactOnPage.length) : []
+
+  const renderCards = (items: typeof paginatedSkills) => (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+      {items.map((skill) => {
+        const category = data.categories.find((c) => c.id === skill.category)
+        return <SkillCard key={skill.id} skill={skill} categoryName={category?.name || skill.category} />
+      })}
+    </div>
+  )
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       {/* Header */}
@@ -98,7 +119,7 @@ export function SkillsClient({ data }: SkillsClientProps) {
             onChange={(e) => setSortBy(e.target.value as SkillSortOption)}
             className="px-3 py-3 border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-900 text-[13px] text-gray-600 dark:text-gray-300 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 dark:focus:border-blue-400 transition-all"
           >
-            <option value="featured">Featured</option>
+            <option value="featured">{searchQuery.trim() ? 'Relevance' : 'Featured'}</option>
             <option value="name">Name</option>
             <option value="recent">Recent</option>
           </select>
@@ -116,17 +137,40 @@ export function SkillsClient({ data }: SkillsClientProps) {
       {filteredSkills.length === 0 ? (
         <div className="text-center py-20">
           <div className="text-5xl mb-4">🔍</div>
-          <p className="text-lg font-semibold text-gray-500 dark:text-gray-400">No skills found</p>
-          <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">Try adjusting your search or filter</p>
+          <p className="text-lg font-semibold text-gray-500 dark:text-gray-400">
+            {searchQuery.trim() ? `No skills match “${searchQuery.trim().replace(/^"|"$/g, '')}”` : 'No skills found'}
+          </p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
+            Try fewer words, or search by category, skill name or id
+          </p>
+          {selectedCategory !== null && (
+            <button
+              type="button"
+              onClick={() => setSelectedCategory(null)}
+              className="mt-4 px-3.5 py-1.5 rounded-full text-[13px] font-medium bg-blue-600 text-white cursor-pointer"
+            >
+              Search all categories
+            </button>
+          )}
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {paginatedSkills.map((skill) => {
-              const category = data.categories.find((c) => c.id === skill.category)
-              return <SkillCard key={skill.id} skill={skill} categoryName={category?.name || skill.category} />
-            })}
-          </div>
+          {exactOnPage.length > 0 && renderCards(exactOnPage)}
+
+          {relatedOnPage.length > 0 && (
+            <>
+              <div className="flex items-center gap-3 mt-8 mb-5">
+                <span className="text-[13px] font-medium text-gray-500 dark:text-gray-400 shrink-0">
+                  {fullMatchCount === 0 ? 'Closest matches' : 'Related skills'}
+                </span>
+                <span className="h-px flex-1 bg-gray-200 dark:bg-gray-700" />
+                <span className="text-[12px] text-gray-400 dark:text-gray-500 shrink-0">
+                  matching some of your terms
+                </span>
+              </div>
+              {renderCards(relatedOnPage)}
+            </>
+          )}
 
           <div className="mt-2">
             <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />

--- a/packages/marketplace/src/components/SearchBar.tsx
+++ b/packages/marketplace/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 interface SearchBarProps {
   onSearch: (query: string) => void
@@ -10,14 +10,41 @@ interface SearchBarProps {
 
 export function SearchBar({ onSearch, placeholder = 'Search skills...', initialValue = '' }: SearchBarProps) {
   const [query, setQuery] = useState(initialValue)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const lastInitialValue = useRef(initialValue)
+
+  // why: the hub reads `?search=` after mount, so the prop arrives late; without this sync the
+  // input renders empty while the results below it are already filtered.
+  useEffect(() => {
+    if (initialValue !== lastInitialValue.current) {
+      lastInitialValue.current = initialValue
+      setQuery(initialValue)
+    }
+  }, [initialValue])
 
   useEffect(() => {
     const timer = setTimeout(() => {
       onSearch(query)
-    }, 300)
+    }, 200)
 
     return () => clearTimeout(timer)
   }, [query, onSearch])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const typingElsewhere = target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement
+      const isSlash = event.key === '/' && !typingElsewhere
+      const isCommandK = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)
+      if (isSlash || isCommandK) {
+        event.preventDefault()
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   return (
     <div className="relative w-full">
@@ -35,12 +62,48 @@ export function SearchBar({ onSearch, placeholder = 'Search skills...', initialV
         <path d="M21 21l-4.35-4.35" />
       </svg>
       <input
-        type="text"
+        ref={inputRef}
+        type="search"
+        role="searchbox"
+        aria-label="Search skills"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape' && query !== '') {
+            e.preventDefault()
+            setQuery('')
+          }
+        }}
         placeholder={placeholder}
-        className="w-full py-3.5 pl-12 pr-4 border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 dark:focus:border-blue-400 transition-all text-[15px]"
+        className="w-full py-3.5 pl-12 pr-20 border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 dark:focus:border-blue-400 transition-all text-[15px] [&::-webkit-search-cancel-button]:hidden"
       />
+      {query === '' ? (
+        <kbd className="absolute right-4 top-1/2 -translate-y-1/2 hidden sm:block px-1.5 py-0.5 rounded border border-gray-200 dark:border-gray-700 text-[11px] text-gray-400 dark:text-gray-500 pointer-events-none">
+          /
+        </kbd>
+      ) : (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => {
+            setQuery('')
+            inputRef.current?.focus()
+          }}
+          className="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      )}
     </div>
   )
 }

--- a/packages/marketplace/src/lib/__tests__/skills-filter.test.ts
+++ b/packages/marketplace/src/lib/__tests__/skills-filter.test.ts
@@ -17,9 +17,24 @@ function skill(partial: Partial<Skill> & Pick<Skill, 'id' | 'name' | 'category'>
 }
 
 const skills: Skill[] = [
-  skill({ id: 'zebra', name: 'Zebra', category: 'writing', metadata: { hasScripts: false, hasReferences: false, referenceFiles: [], lastModified: '2026-01-01' } }),
-  skill({ id: 'tlc-spec-driven', name: 'TLC Spec Driven', category: 'process', metadata: { hasScripts: false, hasReferences: false, referenceFiles: [], lastModified: '2026-06-01' } }),
-  skill({ id: 'accessibility', name: 'Accessibility (a11y)', category: 'frontend', metadata: { hasScripts: false, hasReferences: false, referenceFiles: [], lastModified: '2026-03-01' } }),
+  skill({
+    id: 'zebra',
+    name: 'Zebra',
+    category: 'writing',
+    metadata: { hasScripts: false, hasReferences: false, referenceFiles: [], lastModified: '2026-01-01' },
+  }),
+  skill({
+    id: 'tlc-spec-driven',
+    name: 'TLC Spec Driven',
+    category: 'process',
+    metadata: { hasScripts: false, hasReferences: false, referenceFiles: [], lastModified: '2026-06-01' },
+  }),
+  skill({
+    id: 'accessibility',
+    name: 'Accessibility (a11y)',
+    category: 'frontend',
+    metadata: { hasScripts: false, hasReferences: false, referenceFiles: [], lastModified: '2026-03-01' },
+  }),
 ]
 
 describe('filterAndSortSkills', () => {
@@ -61,6 +76,62 @@ describe('filterAndSortSkills', () => {
       sortBy: 'recent',
     })
     expect(result.map((s) => s.id)).toEqual(['tlc-spec-driven', 'accessibility', 'zebra'])
+  })
+
+  it('ranks search results by relevance under the default featured sort', () => {
+    const result = filterAndSortSkills({
+      skills: [
+        ...skills,
+        skill({
+          id: 'aaa-mentions-zebra',
+          name: 'Aaa Mentions Zebra',
+          category: 'writing',
+          description: 'Talks about zebra.',
+        }),
+      ],
+      searchQuery: 'zebra',
+      selectedCategory: null,
+      sortBy: 'featured',
+    })
+    expect(result.map((s) => s.id)).toEqual(['zebra', 'aaa-mentions-zebra'])
+  })
+
+  it('keeps an explicit name sort even while searching', () => {
+    const result = filterAndSortSkills({
+      skills: [
+        ...skills,
+        skill({
+          id: 'aaa-mentions-zebra',
+          name: 'Aaa Mentions Zebra',
+          category: 'writing',
+          description: 'Talks about zebra.',
+        }),
+      ],
+      searchQuery: 'zebra',
+      selectedCategory: null,
+      sortBy: 'name',
+    })
+    expect(result.map((s) => s.id)).toEqual(['aaa-mentions-zebra', 'zebra'])
+  })
+
+  it('applies search and category together', () => {
+    const result = filterAndSortSkills({
+      skills,
+      searchQuery: 'spec driven',
+      selectedCategory: 'writing',
+      sortBy: 'featured',
+    })
+    expect(result).toEqual([])
+  })
+
+  it('finds multi-word queries whose terms are not adjacent', () => {
+    const result = filterAndSortSkills({
+      skills,
+      searchQuery: 'driven spec',
+      selectedCategory: null,
+      sortBy: 'featured',
+    })
+    expect(result.map((s) => s.id)).toEqual(['tlc-spec-driven'])
   })
 })
 

--- a/packages/marketplace/src/lib/__tests__/skills-search.test.ts
+++ b/packages/marketplace/src/lib/__tests__/skills-search.test.ts
@@ -1,0 +1,199 @@
+import type { Skill } from '../../types'
+import {
+  boundedEditDistance,
+  buildSearchIndex,
+  fuzzyBudget,
+  normalizeText,
+  parseQuery,
+  searchHighlightTerms,
+  searchSkills,
+  stemToken,
+  tokenize,
+} from '../skills-search'
+
+function skill(partial: Partial<Skill> & Pick<Skill, 'id' | 'name' | 'category'>): Skill {
+  return {
+    description: `${partial.name} description`,
+    path: `skills/${partial.id}/SKILL.md`,
+    content: '',
+    metadata: {
+      hasScripts: false,
+      hasReferences: false,
+      referenceFiles: [],
+      lastModified: '2026-01-01',
+    },
+    ...partial,
+  }
+}
+
+const skills: Skill[] = [
+  skill({
+    id: 'react-best-practices',
+    name: 'React Best Practices',
+    category: 'development',
+    description: 'Patterns for building React applications.',
+  }),
+  skill({
+    id: 'evolutionary-modular-architecture',
+    name: 'Evolutionary Modular Architecture',
+    category: 'architecture',
+    description: 'Evolve a modular monolith. Works with React or any frontend.',
+  }),
+  skill({
+    id: 'playwright-skill',
+    name: 'Playwright',
+    category: 'web-automation',
+    description: 'Write end-to-end testing suites for React and other web apps.',
+    content: '# Playwright\n\nUse for browser automation and documentação de testes.',
+  }),
+  skill({
+    id: 'tlc-spec-driven',
+    name: 'TLC Spec Driven',
+    category: 'process',
+    description: 'Spec driven development workflow.',
+  }),
+  skill({
+    id: 'gtm-metrics',
+    name: 'GTM Metrics',
+    category: 'gtm',
+    description: 'Revenue metrics for go-to-market teams.',
+  }),
+]
+
+const categories = [
+  { id: 'gtm', name: 'Go-to-Market' },
+  { id: 'development', name: 'Development' },
+  { id: 'web-automation', name: 'Web Automation' },
+]
+
+const index = buildSearchIndex(skills, categories)
+const ids = (query: string) => searchSkills(index, query).map((result) => result.skill.id)
+
+describe('normalizeText / tokenize', () => {
+  it('folds diacritics and case so accented queries match unaccented text', () => {
+    expect(normalizeText('Documentação')).toBe('documentacao')
+    expect(tokenize('TLC Spec-Driven!')).toEqual(['tlc', 'spec', 'driven'])
+    expect(tokenize('   ')).toEqual([])
+  })
+})
+
+describe('boundedEditDistance / fuzzyBudget', () => {
+  it('measures edits and bails out past the budget', () => {
+    expect(boundedEditDistance('react', 'react', 2)).toBe(0)
+    expect(boundedEditDistance('typscript', 'typescript', 2)).toBe(1)
+    expect(boundedEditDistance('react', 'playwright', 2)).toBeGreaterThan(2)
+  })
+
+  it('only allows typos on terms long enough for one to be plausible', () => {
+    expect(fuzzyBudget('ci')).toBe(0)
+    expect(fuzzyBudget('plan')).toBe(0)
+    expect(fuzzyBudget('react')).toBe(1)
+    expect(fuzzyBudget('typscript')).toBe(2)
+  })
+})
+
+describe('stemToken', () => {
+  it('strips common suffixes so "testing" and "tests" share a stem', () => {
+    expect(stemToken('testing')).toBe(stemToken('tests'))
+    expect(stemToken('deployed')).toBe('deploy')
+    expect(stemToken('metrics')).toBe('metric')
+  })
+
+  it('leaves short words and double-s endings alone', () => {
+    expect(stemToken('ci')).toBe('ci')
+    expect(stemToken('css')).toBe('css')
+    expect(stemToken('ring')).toBe('ring')
+  })
+})
+
+describe('parseQuery', () => {
+  it('splits bare terms from quoted phrases', () => {
+    const parsed = parseQuery('"spec driven" react testing')
+    expect(parsed.phrases).toEqual(['spec driven'])
+    expect(parsed.terms).toEqual(['react', 'testing'])
+  })
+})
+
+describe('searchSkills', () => {
+  it('ranks the skill named after the query first', () => {
+    expect(ids('react')[0]).toBe('react-best-practices')
+  })
+
+  it('matches multi-word queries whose terms are not adjacent', () => {
+    expect(ids('testing react')[0]).toBe('playwright-skill')
+    expect(ids('driven spec')).toContain('tlc-spec-driven')
+  })
+
+  it('ranks skills matching every term above skills matching only some', () => {
+    expect(ids('react architecture')[0]).toBe('evolutionary-modular-architecture')
+  })
+
+  it('falls back to partial matches instead of an empty page', () => {
+    const results = searchSkills(index, 'react zzzzzz')
+    expect(results.length).toBeGreaterThan(0)
+    expect(results.every((result) => result.partial)).toBe(true)
+    expect(results[0].matchedTerms).toBe(1)
+  })
+
+  it('returns nothing when no term matches at all', () => {
+    expect(ids('zzzzzz qqqqqq')).toEqual([])
+  })
+
+  it('matches across singular/plural and verb forms', () => {
+    expect(ids('test')).toContain('playwright-skill')
+    expect(ids('patterns')).toContain('react-best-practices')
+  })
+
+  it('puts skills matching every term ahead of skills matching only some', () => {
+    const results = searchSkills(index, 'testing react')
+    expect(results[0].skill.id).toBe('playwright-skill')
+    expect(results[0].partial).toBe(false)
+    expect(results.slice(1).every((result) => result.partial)).toBe(true)
+  })
+
+  it('tolerates typos on long enough terms', () => {
+    expect(ids('reakt')).toContain('react-best-practices')
+    expect(ids('playwrigth')).toContain('playwright-skill')
+  })
+
+  it('matches short terms as whole tokens only, never as substrings of longer words', () => {
+    expect(ids('gtm')).toEqual(['gtm-metrics'])
+    expect(ids('ci')).toEqual([])
+  })
+
+  it('matches hyphenated ids typed with spaces and vice versa', () => {
+    expect(ids('spec-driven')).toContain('tlc-spec-driven')
+    expect(ids('react best practices')[0]).toBe('react-best-practices')
+  })
+
+  it('searches category names, not just the category id', () => {
+    expect(ids('go-to-market')[0]).toBe('gtm-metrics')
+  })
+
+  it('searches skill content and folds accents', () => {
+    expect(ids('documentacao')).toEqual(['playwright-skill'])
+    expect(ids('documentacão')).toEqual(['playwright-skill'])
+  })
+
+  it('honours quoted phrases as exact sequences', () => {
+    expect(ids('"spec driven"')).toContain('tlc-spec-driven')
+    expect(ids('"driven spec"')).toEqual([])
+    expect(ids('"spec driven" zzzzzz').length).toBeGreaterThan(0)
+  })
+
+  it('returns every skill for a blank query', () => {
+    expect(ids('   ')).toHaveLength(skills.length)
+  })
+
+  it('breaks score ties alphabetically so order is stable', () => {
+    const first = searchSkills(index, 'react')
+    const second = searchSkills(index, 'react')
+    expect(first.map((r) => r.skill.id)).toEqual(second.map((r) => r.skill.id))
+  })
+})
+
+describe('searchHighlightTerms', () => {
+  it('returns terms worth highlighting, including words inside phrases', () => {
+    expect(searchHighlightTerms('"spec driven" react a').sort()).toEqual(['driven', 'react', 'spec'])
+  })
+})

--- a/packages/marketplace/src/lib/skills-filter.ts
+++ b/packages/marketplace/src/lib/skills-filter.ts
@@ -1,4 +1,5 @@
-import type { Skill } from '../types'
+import type { Category, Skill } from '../types'
+import { buildSearchIndex, searchSkills, type SkillSearchDoc } from './skills-search'
 
 export type SkillSortOption = 'featured' | 'name' | 'recent'
 
@@ -8,44 +9,76 @@ export interface SkillsFilterInput {
   selectedCategory: string | null
   sortBy: SkillSortOption
   featuredSkillId?: string
+  /** Prebuilt index; pass one from a `useMemo` so typing does not re-normalize the catalog. */
+  searchIndex?: SkillSearchDoc[]
+  /** Category names, so a search for "Go-to-Market" matches skills in the `gtm` category. */
+  categories?: Category[]
+}
+
+export interface SkillsFilterResult {
+  skills: Skill[]
+  /** How many leading results matched every query term; the rest are looser matches. */
+  fullMatchCount: number
 }
 
 /**
  * Pure filter/sort used by the skills hub client — unit-tested so filter UX
  * regressions are caught without a browser harness.
+ *
+ * why: with a query present, `featured` means "best match first" — pinning one skill above a
+ * direct hit for its own name is what made search feel broken. Explicit `name` / `recent`
+ * choices always win, since the user asked for that order.
  */
-export function filterAndSortSkills({
+export function filterAndSortSkillsWithMeta({
   skills,
   searchQuery,
   selectedCategory,
   sortBy,
   featuredSkillId = 'tlc-spec-driven',
-}: SkillsFilterInput): Skill[] {
-  const normalizedQuery = searchQuery.trim().toLowerCase()
-  let result = skills.filter((skill) => {
-    const matchesSearch =
-      normalizedQuery === '' ||
-      skill.name.toLowerCase().includes(normalizedQuery) ||
-      skill.description.toLowerCase().includes(normalizedQuery)
+  searchIndex,
+  categories,
+}: SkillsFilterInput): SkillsFilterResult {
+  const inCategory = selectedCategory === null ? skills : skills.filter((skill) => skill.category === selectedCategory)
 
-    const matchesCategory = selectedCategory === null || skill.category === selectedCategory
+  const hasQuery = searchQuery.trim() !== ''
+  let result: Skill[]
+  let fullMatchCount: number
 
-    return matchesSearch && matchesCategory
-  })
+  if (hasQuery) {
+    const allowed = new Set(inCategory.map((skill) => skill.id))
+    const docs = (searchIndex ?? buildSearchIndex(skills, categories)).filter((doc) => allowed.has(doc.skill.id))
+    const matches = searchSkills(docs, searchQuery)
+    fullMatchCount = matches.filter((match) => !match.partial).length
+    result = matches.map((match) => match.skill)
+    if (sortBy === 'featured') return { skills: result, fullMatchCount }
+  } else {
+    result = [...inCategory]
+    fullMatchCount = result.length
+  }
 
-  if (sortBy === 'featured') {
-    result = [...result].sort((a, b) => {
+  if (sortBy === 'recent') {
+    return {
+      skills: [...result].sort((a, b) => b.metadata.lastModified.localeCompare(a.metadata.lastModified)),
+      fullMatchCount,
+    }
+  }
+  if (sortBy === 'name') {
+    return { skills: [...result].sort((a, b) => a.name.localeCompare(b.name)), fullMatchCount }
+  }
+
+  return {
+    skills: [...result].sort((a, b) => {
       if (a.id === featuredSkillId) return -1
       if (b.id === featuredSkillId) return 1
       return a.name.localeCompare(b.name)
-    })
-  } else if (sortBy === 'recent') {
-    result = [...result].sort((a, b) => b.metadata.lastModified.localeCompare(a.metadata.lastModified))
-  } else {
-    result = [...result].sort((a, b) => a.name.localeCompare(b.name))
+    }),
+    fullMatchCount,
   }
+}
 
-  return result
+/** Skills-only view of {@link filterAndSortSkillsWithMeta}. */
+export function filterAndSortSkills(input: SkillsFilterInput): Skill[] {
+  return filterAndSortSkillsWithMeta(input).skills
 }
 
 export function paginateSkills<T>(items: T[], currentPage: number, pageSize: number): T[] {

--- a/packages/marketplace/src/lib/skills-search.ts
+++ b/packages/marketplace/src/lib/skills-search.ts
@@ -1,0 +1,284 @@
+import type { Category, Skill } from '../types'
+
+/** invariant: content is indexed only up to this many characters, so a long SKILL.md body
+ * cannot dominate index size or dilute scoring. */
+const CONTENT_INDEX_LIMIT = 4000
+
+/** invariant: terms this short only match whole tokens or token prefixes — letting "ci" match
+ * inside "prin-ci-ples" buries the one skill actually about CI. */
+const MIN_INFIX_TERM_LENGTH = 3
+
+const FIELD_WEIGHTS = {
+  name: { exact: 100, prefix: 60, infix: 34, fuzzy: 24 },
+  id: { exact: 90, prefix: 55, infix: 30, fuzzy: 20 },
+  category: { exact: 45, prefix: 28, infix: 16, fuzzy: 0 },
+  description: { exact: 22, prefix: 14, infix: 9, fuzzy: 6 },
+  content: { exact: 4, prefix: 2, infix: 1, fuzzy: 0 },
+} as const
+
+type FieldName = keyof typeof FIELD_WEIGHTS
+
+/** Whole-query bonuses, applied on top of per-term scores. */
+const EXACT_NAME_BONUS = 400
+const EXACT_ID_BONUS = 360
+const NAME_PREFIX_BONUS = 180
+const NAME_PHRASE_BONUS = 90
+
+interface IndexedField {
+  text: string
+  tokens: string[]
+  stems: string[]
+}
+
+export interface SkillSearchDoc {
+  skill: Skill
+  fields: Record<FieldName, IndexedField>
+  /** Normalized name + id + category, used for whole-query bonuses. */
+  normalizedName: string
+  normalizedId: string
+}
+
+export interface SkillSearchResult {
+  skill: Skill
+  score: number
+  /** How many query terms this skill matched. */
+  matchedTerms: number
+  /** True when the skill matched only some of the query terms. */
+  partial: boolean
+}
+
+interface DocScore {
+  score: number
+  matchedTerms: number
+}
+
+export interface ParsedQuery {
+  /** Bare terms; skills matching all of them rank above skills matching only some. */
+  terms: string[]
+  /** Quoted phrases; each must appear verbatim in some field. */
+  phrases: string[]
+  /** Whole normalized query, used for the name-prefix / exact bonuses. */
+  normalized: string
+}
+
+/**
+ * Lowercase and strip diacritics so "documentação" and "documentacao" are the same token.
+ */
+export function normalizeText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * why: a query for "testing" should find a skill that says "tests". This is a deliberately
+ * small suffix stripper, not a full stemmer — aggressive stemming collapses unrelated words
+ * and the catalog is short enough that precision matters more than recall.
+ */
+export function stemToken(token: string): string {
+  if (token.length > 5 && token.endsWith('ing')) return token.slice(0, -3)
+  if (token.length > 4 && token.endsWith('ed')) return token.slice(0, -2)
+  if (token.length > 4 && token.endsWith('es')) return token.slice(0, -2)
+  if (token.length > 3 && token.endsWith('s') && !token.endsWith('ss')) return token.slice(0, -1)
+  return token
+}
+
+export function tokenize(value: string): string[] {
+  const normalized = normalizeText(value)
+  return normalized === '' ? [] : normalized.split(' ')
+}
+
+function uniqueTokens(value: string): IndexedField {
+  const text = normalizeText(value)
+  const tokens = text === '' ? [] : Array.from(new Set(text.split(' ')))
+  return { text, tokens, stems: Array.from(new Set(tokens.map(stemToken))) }
+}
+
+/**
+ * Damerau-less bounded Levenshtein: returns a distance capped at `max`, bailing out as soon
+ * as no cell in a row can still come in under the budget.
+ */
+export function boundedEditDistance(a: string, b: string, max: number): number {
+  if (a === b) return 0
+  if (Math.abs(a.length - b.length) > max) return max + 1
+
+  let previous = new Array<number>(b.length + 1)
+  let current = new Array<number>(b.length + 1)
+  for (let j = 0; j <= b.length; j += 1) previous[j] = j
+
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i
+    let rowMin = current[0]
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, previous[j - 1] + cost)
+      if (current[j] < rowMin) rowMin = current[j]
+    }
+    if (rowMin > max) return max + 1
+    const swap = previous
+    previous = current
+    current = swap
+  }
+
+  return previous[b.length]
+}
+
+/**
+ * why: one edit on a 4-letter word ("plan" -> "plaf") is as likely to be a different word as
+ * a typo, so tolerance only opens up as terms get longer.
+ */
+export function fuzzyBudget(term: string): number {
+  if (term.length >= 8) return 2
+  if (term.length >= 5) return 1
+  return 0
+}
+
+export function parseQuery(query: string): ParsedQuery {
+  const phrases: string[] = []
+  const remainder = query.replace(/"([^"]+)"/g, (_match, phrase: string) => {
+    const normalized = normalizeText(phrase)
+    if (normalized) phrases.push(normalized)
+    return ' '
+  })
+
+  return {
+    terms: tokenize(remainder),
+    phrases,
+    normalized: normalizeText(query.replace(/"/g, ' ')),
+  }
+}
+
+export function buildSearchDoc(skill: Skill, categoryName?: string): SkillSearchDoc {
+  const name = uniqueTokens(skill.name)
+  const id = uniqueTokens(skill.id)
+  return {
+    skill,
+    normalizedName: name.text,
+    normalizedId: id.text,
+    fields: {
+      name,
+      id,
+      category: uniqueTokens(`${skill.category} ${categoryName ?? ''}`),
+      description: uniqueTokens(skill.description),
+      content: uniqueTokens(skill.content.slice(0, CONTENT_INDEX_LIMIT)),
+    },
+  }
+}
+
+export function buildSearchIndex(skills: Skill[], categories: Category[] = []): SkillSearchDoc[] {
+  const categoryNames = new Map(categories.map((category) => [category.id, category.name]))
+  return skills.map((skill) => buildSearchDoc(skill, categoryNames.get(skill.category)))
+}
+
+/** Best score a single term can earn from one field, or 0 when the field does not match it. */
+function scoreTermInField(term: string, field: IndexedField, weights: (typeof FIELD_WEIGHTS)[FieldName]): number {
+  if (field.text === '') return 0
+
+  let best = 0
+  for (const token of field.tokens) {
+    if (token === term) return weights.exact
+    if (token.startsWith(term)) {
+      best = Math.max(best, weights.prefix)
+      continue
+    }
+    if (term.length >= MIN_INFIX_TERM_LENGTH && token.includes(term)) best = Math.max(best, weights.infix)
+  }
+  if (best > 0) return best
+
+  const stem = stemToken(term)
+  if (stem !== term || term.length > 3) {
+    if (field.stems.includes(stem)) return weights.infix
+  }
+
+  if (weights.fuzzy > 0) {
+    const budget = fuzzyBudget(term)
+    if (budget > 0) {
+      for (const token of field.tokens) {
+        if (boundedEditDistance(term, token, budget) <= budget) return weights.fuzzy
+      }
+    }
+  }
+
+  return 0
+}
+
+/**
+ * Score one skill against a parsed query, reporting how many terms it matched. Returns `null`
+ * when the skill matched nothing at all, or when a quoted phrase is missing — a phrase is an
+ * explicit demand, so it is the one hard filter.
+ */
+export function scoreDoc(doc: SkillSearchDoc, query: ParsedQuery): DocScore | null {
+  for (const phrase of query.phrases) {
+    const found = (Object.keys(doc.fields) as FieldName[]).some((field) => doc.fields[field].text.includes(phrase))
+    if (!found) return null
+  }
+
+  let score = 0
+  let matchedTerms = 0
+  for (const term of query.terms) {
+    let termScore = 0
+    for (const field of Object.keys(doc.fields) as FieldName[]) {
+      termScore += scoreTermInField(term, doc.fields[field], FIELD_WEIGHTS[field])
+    }
+    if (termScore > 0) {
+      matchedTerms += 1
+      score += termScore
+    }
+  }
+  if (matchedTerms === 0 && query.phrases.length === 0) return null
+
+  if (query.phrases.length > 0 && query.terms.length === 0) score += NAME_PHRASE_BONUS
+
+  const whole = query.normalized
+  if (whole) {
+    if (doc.normalizedName === whole) score += EXACT_NAME_BONUS
+    else if (doc.normalizedId === whole) score += EXACT_ID_BONUS
+    else if (doc.normalizedName.startsWith(whole) || doc.normalizedId.startsWith(whole)) score += NAME_PREFIX_BONUS
+    else if (doc.normalizedName.includes(whole)) score += NAME_PHRASE_BONUS
+  }
+
+  return { score, matchedTerms }
+}
+
+/**
+ * Rank skills for a query. Ties break alphabetically so the order is stable across renders.
+ *
+ * why: skills matching every term come first, so adding a word narrows as the user expects.
+ * Skills matching only some terms follow instead of being dropped — demanding every term
+ * would hand back an empty page for a reasonable query like "testing react". The caller can
+ * tell the two groups apart through `partial` and label them.
+ */
+export function searchSkills(docs: SkillSearchDoc[], query: string): SkillSearchResult[] {
+  const parsed = parseQuery(query)
+  if (parsed.terms.length === 0 && parsed.phrases.length === 0) {
+    return docs.map((doc) => ({ skill: doc.skill, score: 0, matchedTerms: 0, partial: false }))
+  }
+
+  const full: SkillSearchResult[] = []
+  const partial: SkillSearchResult[] = []
+  for (const doc of docs) {
+    const scored = scoreDoc(doc, parsed)
+    if (scored === null) continue
+    const isFull = scored.matchedTerms === parsed.terms.length
+    const entry = { skill: doc.skill, score: scored.score, matchedTerms: scored.matchedTerms, partial: !isFull }
+    ;(isFull ? full : partial).push(entry)
+  }
+
+  const byRelevance = (a: SkillSearchResult, b: SkillSearchResult) =>
+    b.matchedTerms - a.matchedTerms || b.score - a.score || a.skill.name.localeCompare(b.skill.name)
+
+  return [...full.sort(byRelevance), ...partial.sort(byRelevance)]
+}
+
+/**
+ * Terms to highlight in result cards — bare terms plus the words inside quoted phrases.
+ */
+export function searchHighlightTerms(query: string): string[] {
+  const parsed = parseQuery(query)
+  const terms = new Set<string>([...parsed.terms, ...parsed.phrases.flatMap((phrase) => phrase.split(' '))])
+  return Array.from(terms).filter((term) => term.length > 1)
+}


### PR DESCRIPTION
# fix(marketplace): busca de skills que realmente encontra

## O que muda

A busca da página `/skills/` era um `includes()` de texto. Agora é uma busca com ranking,
tolerante a erro de digitação, que olha nome, id, categoria, descrição e o conteúdo da skill.

Closes #<!-- número da issue -->

---

## Por quê

A busca antiga era isto, em `skills-filter.ts`:

```ts
skill.name.toLowerCase().includes(query) || skill.description.toLowerCase().includes(query)
```

Rodando essas consultas no catálogo real (92 skills), o resultado era:

| Busca | Antes | Problema |
| --- | --- | --- |
| `testing react` | 0 resultados | as palavras precisavam estar coladas, na mesma ordem |
| `driven spec` | 0 resultados | mesma coisa |
| `typscript` | 0 resultados | um erro de digitação zerava a busca |
| `ci` | `ai-pricing`, `create-adr`, ... | casava dentro de "pri**ci**ng", "de**ci**são" |
| `react` | `evolutionary-modular-architecture` em 1º | ordem alfabética, sem relevância |

Além disso: id, categoria e o corpo do `SKILL.md` nunca eram consultados, e acento não era
normalizado.

E tinha um bug de UI junto: abrir `/skills/?search=react` filtrava os resultados mas deixava a
caixa de busca **vazia**. O `SearchBar` lia `initialValue` só na montagem, e a página só lê a
URL depois de montar.

---

## O que tem no PR

### Novo: `src/lib/skills-search.ts`

Um motor de busca próprio, sem dependência nova (nada de Fuse.js — são 92 skills e o índice
inteiro sai em 12ms).

- **Campos com peso** — nome > id > categoria > descrição > conteúdo. Cada termo pontua por
  igualdade, prefixo, trecho interno ou similaridade, nessa ordem.
- **Todos os termos, com plano B** — quem casa com todas as palavras vem primeiro. Quem casa
  com só algumas aparece depois, separado e rotulado como "Related skills", em vez de virar
  página vazia.
- **Erro de digitação** — distância de Levenshtein com corte antecipado. O limite cresce com o
  tamanho da palavra: nada abaixo de 5 letras, para `plan` não virar `plaf`.
- **Singular/plural e verbo** — `testing` acha `tests`, `metrics` acha `metric`.
- **Acento** — `documentação` e `documentacao` são a mesma coisa.
- **Frase exata entre aspas** — `"spec driven"` acha; `"driven spec"` não acha nada.
- **Palavra curta** — com menos de 3 letras só casa a palavra inteira ou o começo dela. É o que
  faz `ci` devolver `nx-ci-monitor` em primeiro em vez de ruído.

O conteúdo do `SKILL.md` entra no índice até 4000 caracteres, para um arquivo grande não
dominar o índice nem diluir a pontuação.

### Ranking

Com busca ativa, o "Featured" vira ordenação por relevância e o rótulo do select muda para
"Relevance". Fixar uma skill acima de quem casa exatamente com o nome buscado era parte do que
fazia a busca parecer quebrada. Se a pessoa escolher "Name" ou "Recent" na mão, a escolha dela
ganha.

Resultados no catálogo real, depois:

| Busca | Primeiros resultados |
| --- | --- |
| `react` | `react-composition-patterns`, `react-native-expert`, `react-best-practices` |
| `deploy vercel` | `vercel-deploy`, depois cloudflare / render / netlify |
| `security threat` | `security-threat-model` |
| `skill architect` | `skill-architect` |
| `ci` | `nx-ci-monitor`, `gh-fix-ci` |
| `reakt navtive` (2 erros) | `react-native-expert` |

### Correções de UI

- **`SearchBar.tsx`** — sincroniza `initialValue`, então `?search=` agora aparece na caixa.
  Ganhou também botão de limpar, atalho `/` e `⌘K` para focar, `Esc` para limpar, e
  `aria-label`. O debounce caiu de 300ms para 200ms.
- **`SkillsClient.tsx`** — o índice é construído uma vez por `useMemo`, não a cada tecla. Tela
  de "nenhum resultado" agora mostra o termo buscado e, se tiver categoria filtrada, um botão
  "Search all categories".

---

## Testes

```
npm run test    # 5 projetos, tudo passando
npm run build   # 6 projetos, tudo passando
```

| | |
| --- | --- |
| `nx test marketplace` | 76 passando (era 50 — 26 testes novos, nenhum removido) |
| `nx test` cli / core / tools / skills-catalog | 195 / 127 / 109 / 9 |
| `nx build` (6 projetos) | passa |
| `tsc --noEmit` | limpo |
| eslint nos arquivos alterados | limpo |
| prettier nos arquivos alterados | limpo |

Os testes novos cobrem cada comportamento acima: termos fora de ordem, erro de digitação,
palavra curta, acento, frase entre aspas, stemming, ranking de match completo vs. parcial e
estabilidade da ordenação.

**Verificado no navegador**, com `next dev` rodando:

- `?search=testing react` → 2 matches completos, depois a divisória "Related skills"
- `reakt navtive` digitado na mão → `React Native Expert` como único match completo
- `"spec driven"` → as 4 skills de spec
- `?search=react` → agora aparece escrito na caixa de busca
- sem erro no console

### Falhas que já existiam

`npm run lint` está vermelho no repositório inteiro (427 erros no `main`, mesmos 427 aqui) e
`npx prettier --check` acusa 8 arquivos do marketplace. Nenhum dos dois é deste PR — os
arquivos que eu toquei passam nos dois. Arrumar isso é outro PR.

---

## Escopo

6 arquivos, `+734 / −40`. Desses, 483 linhas são os dois arquivos novos
(`skills-search.ts`, 284 linhas, e `skills-search.test.ts`, 199 linhas). Nenhuma dependência
nova, nenhuma skill alterada, nenhum dado regerado.

Ficou de fora de propósito:

- **Destacar o termo buscado no card** — `searchHighlightTerms()` já está exportado e testado,
  mas pintar o texto mexe no `SkillCard` e é decisão de design.
- **Busca do CLI** — o `packages/cli` tem o próprio índice de busca. O mesmo motor serviria lá,
  mas é outro PR.
- **Sinônimos** (`a11y` → `accessibility`, `e2e` → `testing`) — precisa de um vocabulário
  curado antes, senão vira chute.

## Uma decisão que vale revisar

Testei duas formas de ordenar quando ninguém casa com todos os termos. A primeira misturava
tudo numa pontuação só, ponderada por quantos termos casaram — e aí um match fraco no corpo de
uma skill passava na frente de um match direto no nome. A que ficou separa em dois grupos:
match completo primeiro, parcial depois com rótulo. É mais previsível e dá para explicar na
tela.

---

## Checklist

- [ ] Implementa uma issue que um mantenedor aprovou
- [ ] `npx nx affected -t lint test build --base=origin/main` passa localmente — **não passa**,
      o lint já está vermelho no `main`. Tudo que este PR toca compila, testa e linta limpo.
- [x] Mensagens de commit no padrão convencional (`feat:`, `fix:`, `docs:`, `chore:`)
- [x] Skill nova ou alterada: nenhuma skill foi tocada
- [x] Arquivos de skill empacotados: n/a
- [ ] Um agente de IA participou, e eu revisei linha por linha — ou nenhum agente participou

https://claude.ai/code/session_017d6uxbYyNVFQ4EgF2gdmVh
